### PR TITLE
Fix the way current directory was being obtained.

### DIFF
--- a/csharp/GSDK_CSharp_Standard/FilesystemLogger.cs
+++ b/csharp/GSDK_CSharp_Standard/FilesystemLogger.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Playfab.Gaming.GSDK.CSharp
                 return;
             }
 
-            // Workaround to enable .Net 4.5 and netstandard1.6 (instead of using Environment.CurrentDirectory).
-            string currentDirectory = typeof(FilesystemLogger).GetTypeInfo().Assembly.Location;
+            string currentDirectory = Directory.GetCurrentDirectory();
             if (string.IsNullOrWhiteSpace(_logFolder))
             {
                 _logFolder = currentDirectory;


### PR DESCRIPTION
Using typeof(Type).GetTypeInfo().Assembly.location gives the filename instead of the directory. This was caught while publishing the nuget and the tests kept getting stuck (needs separate investigation).  I had tested the winrunner with this version and it passed golden path so I am not sure how that passed.