### PR TITLE
Update GSDK to use OrdinalIgnoreCase for the configuration dictionary.

### DIFF
--- a/csharp/GSDK_CSharp_Standard/GameserverSDK.cs
+++ b/csharp/GSDK_CSharp_Standard/GameserverSDK.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Playfab.Gaming.GSDK.CSharp
             Task.WhenAll(_internalSdk.StartAsync())
                 .Wait();
 
-            return new Dictionary<string, string>(_internalSdk.ConfigMap);
+            return new Dictionary<string, string>(_internalSdk.ConfigMap, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/csharp/GSDK_CSharp_Standard/InternalSdk.cs
+++ b/csharp/GSDK_CSharp_Standard/InternalSdk.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Playfab.Gaming.GSDK.CSharp
 
         private IDictionary<string, string> CreateConfigMap(Configuration localConfig)
         {
-            var finalConfig = new Dictionary<string, string>();
+            var finalConfig = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (KeyValuePair<string, string> certEntry in localConfig.GameCertificates)
             {


### PR DESCRIPTION
Update GSDK to use OrdinalIgnoreCase for the configuration dictionary.
Fixed the way asset file was read in the runner app so that it works for both containers and processes.