### PR TITLE
Catch exception when failing to parse contents of heartbeat

### DIFF
--- a/cpp/unittests/gsdkTests.cpp
+++ b/cpp/unittests/gsdkTests.cpp
@@ -168,7 +168,7 @@ namespace Microsoft
                     Assert::IsTrue(GSDKInternal::m_instance->m_heartbeatRequest.m_currentGameState == GameState::Active, L"Verify state was changed.");
                 }
 
-                TEST_METHOD(DecodeAgentResponseJsonDoesntCrash)
+                TEST_METHOD(DecodeAgentResponse_JsonDoesntCrash)
                 {
                     GSDKInternal::testConfiguration = std::make_unique<TestConfig>("heartbeatEndpoint", "serverId", "logFolder", "sharedContentFolder");
                     GSDK::start();
@@ -191,7 +191,7 @@ namespace Microsoft
                     GSDKInternal::m_instance->decodeHeartbeatResponse(responseJson);
                 }
 
-                TEST_METHOD(DecodeAgentResponseJsonDoesntCrashWhenInvalidJson)
+                TEST_METHOD(DecodeAgentResponse_JsonDoesntCrashWhenInvalidJson)
                 {
                     GSDKInternal::testConfiguration = std::make_unique<TestConfig>("heartbeatEndpoint", "serverId", "logFolder", "sharedContentFolder");
                     GSDK::start();

--- a/cpp/unittests/gsdkTests.cpp
+++ b/cpp/unittests/gsdkTests.cpp
@@ -168,6 +168,52 @@ namespace Microsoft
                     Assert::IsTrue(GSDKInternal::m_instance->m_heartbeatRequest.m_currentGameState == GameState::Active, L"Verify state was changed.");
                 }
 
+                TEST_METHOD(DecodeAgentResponseJsonDoesntCrash)
+                {
+                    GSDKInternal::testConfiguration = std::make_unique<TestConfig>("heartbeatEndpoint", "serverId", "logFolder", "sharedContentFolder");
+                    GSDK::start();
+
+                    time_t maintenanceTime;
+                    GSDK::registerMaintenanceCallback([&maintenanceTime](tm t) -> void { maintenanceTime = _mkgmtime(&t); });
+
+                    std::string responseJson =
+                        R"({
+                                "operation": {
+                                    "status": "Active"
+                                },
+                                "sessionConfig":
+                                {
+                                    "sessionId":"eca7e870-da2e-45f9-bb66-30d89064313a",
+                                    "sessionCookie":"OreoCookie"
+                                },
+                                "nextScheduledMaintenanceUtc":"2018-04-12T16:58:30.1458776Z"
+                        }")";
+                    GSDKInternal::m_instance->decodeHeartbeatResponse(responseJson);
+                }
+
+                TEST_METHOD(DecodeAgentResponseJsonDoesntCrashWhenInvalidJson)
+                {
+                    GSDKInternal::testConfiguration = std::make_unique<TestConfig>("heartbeatEndpoint", "serverId", "logFolder", "sharedContentFolder");
+                    GSDK::start();
+
+                    time_t maintenanceTime;
+                    GSDK::registerMaintenanceCallback([&maintenanceTime](tm t) -> void { maintenanceTime = _mkgmtime(&t); });
+
+                    std::string responseJson =
+                        R"({
+                                "operation": {
+                                    "status": "Active"
+                                },
+                                "sessionConfig":
+                                {
+                                    "sessionId":"eca7e870-da2e-45f9-bb66-30d89064313a",
+                                    "sessionCookie":"OreoCookie"
+                                },
+                                "nextScheduledMaintenanceUtc":"2018-04-12T16:58:30.1458776Z",
+                        }")";
+                    GSDKInternal::m_instance->decodeHeartbeatResponse(responseJson);
+                }
+
                 TEST_METHOD(ReturnInitialPlayerListFromJson)
                 {
                     GSDKInternal::testConfiguration = std::make_unique<TestConfig>("heartbeatEndpoint", "serverId", "logFolder", "sharedContentFolder");


### PR DESCRIPTION
This PR addresses two issues

1. In case a heartbeat is valid JSON but not in the expected format, an unhandled exception will be thrown.
Catch the exception and log the error message along with the full JSON string.

2. In case the heartbeat is invalid JSON, we currently ignore it completed.
Log an error in the log along with the JSON string.
