### PR TITLE
CPP GSDK: Added support for querying game server connection info

### DIFF
--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -76,11 +76,15 @@ namespace Microsoft
                 m_configSettings[GSDK::TITLE_ID_KEY] = config->getTitleId();
                 m_configSettings[GSDK::BUILD_ID_KEY] = config->getBuildId();
                 m_configSettings[GSDK::REGION_KEY] = config->getRegion();
+                m_configSettings[GSDK::PUBLIC_IP_V4_ADDRESS_KEY] = config->getPublicIpV4Address();
+                m_configSettings[GSDK::FULLY_QUALIFIED_DOMAIN_NAME_KEY] = config->getFullyQualifiedDomainName();
 
                 if (m_configSettings[GSDK::HEARTBEAT_ENDPOINT_KEY].empty() || m_configSettings[GSDK::SERVER_ID_KEY].empty())
                 {
                     throw GSDKInitializationException("Heartbeat endpoint and Server id are required configuration values.");
                 }
+
+                m_connectionInfo = config->getGameServerConnectionInfo();
 
                 // We don't want to write files in our UTs
                 if (config->shouldLog())
@@ -411,6 +415,11 @@ namespace Microsoft
                 }
 
                 return GSDKInternal::get().m_heartbeatRequest.m_currentGameState == GameState::Active;
+            }
+
+            const Microsoft::Azure::Gaming::GameServerConnectionInfo &GSDK::getGameServerConnectionInfo()
+            {
+                return GSDKInternal::get().m_connectionInfo;
             }
 
             const std::unordered_map<std::string, std::string>& GSDK::getConfigSettings()

--- a/cpp/cppsdk/gsdk.h
+++ b/cpp/cppsdk/gsdk.h
@@ -26,6 +26,54 @@ namespace Microsoft
                 }
             };
 
+            /// <summary>
+            /// A class that captures details about a game server port.
+            /// </summary>
+            class GamePort
+            {
+                public:
+                    /// <summary>
+                    /// The friendly name / identifier for the port, specified by the game developer in the Build configuration.
+                    /// </summary>
+                    std::string m_name;
+
+                    /// <summary>
+                    /// The port at which the game server should listen on (maps externally to <see cref="m_clientConnectionPort" />).
+                    /// For process based servers, this is determined by Control Plane, based on the ports available on the VM.
+                    /// For containers, this is specified by the game developer in the Build configuration.
+                    /// </summary>
+                    int m_serverListeningPort;
+
+                    /// <summary>
+                    /// The public port to which clients should connect (maps internally to <see cref="m_serverListeningPort" />).
+                    /// </summary>
+                    int m_clientConnectionPort;
+
+                    GamePort() {}
+
+                    GamePort(std::string name, int serverListeningPort, int clientConnectionPort)
+                    {
+                        m_name = name;
+                        m_serverListeningPort = serverListeningPort;
+                        m_clientConnectionPort = clientConnectionPort;
+                    }
+            };
+
+            class GameServerConnectionInfo
+            {
+                public:
+                    std::string m_publicIpV4Address;
+                    std::vector<GamePort> m_gamePortsConfiguration;
+
+                    GameServerConnectionInfo() {}
+
+                    GameServerConnectionInfo(std::string publicIpV4Address, std::vector<GamePort> gamePortsConfiguration)
+                    {
+                        m_publicIpV4Address = publicIpV4Address;
+                        m_gamePortsConfiguration = gamePortsConfiguration;
+                    }
+            };
+
             class GSDKInitializationException : public std::runtime_error
             {
                 using std::runtime_error::runtime_error;
@@ -38,6 +86,13 @@ namespace Microsoft
                 /// <remarks>Required. This is a blocking call and will only return when this server is either allocated (a player is about to connect) or terminated.</remarks>
                 /// <returns>True if the server is allocated (will receive players shortly). False if the server is terminated. </returns>
                 static bool readyForPlayers();
+
+                /// <summary>
+                /// Gets information (ipAddress and ports) for connecting to the game server, as well as the ports the
+                /// game server should listen on.
+                /// </summary>
+                /// <returns></returns>
+                static const GameServerConnectionInfo &getGameServerConnectionInfo();
 
                 /// <summary>Returns all configuration settings</summary>
                 /// <returns>unordered map of string key:value configuration setting values</returns>
@@ -82,6 +137,9 @@ namespace Microsoft
                 static constexpr const char* TITLE_ID_KEY = "titleId";
                 static constexpr const char* BUILD_ID_KEY = "buildId";
                 static constexpr const char* REGION_KEY = "region";
+                static constexpr const char* VM_ID_KEY = "vmId";
+                static constexpr const char* PUBLIC_IP_V4_ADDRESS_KEY = "publicIpV4Address";
+                static constexpr const char* FULLY_QUALIFIED_DOMAIN_NAME_KEY = "fullyQualifiedDomainName";
 
                 // These two keys are only available after allocation (once readyForPlayers returns true)
                 static constexpr const char* SESSION_COOKIE_KEY = "sessionCookie";

--- a/cpp/cppsdk/gsdkConfig.cpp
+++ b/cpp/cppsdk/gsdkConfig.cpp
@@ -88,6 +88,21 @@ const std::unordered_map<std::string, std::string> &Microsoft::Azure::Gaming::En
     return m_ports;
 }
 
+const std::string &Microsoft::Azure::Gaming::EnvironmentVariableConfiguration::getPublicIpV4Address()
+{
+    return m_ipv4Address;
+}
+
+const std::string &Microsoft::Azure::Gaming::EnvironmentVariableConfiguration::getFullyQualifiedDomainName()
+{
+    return m_domainName;
+}
+
+const Microsoft::Azure::Gaming::GameServerConnectionInfo &Microsoft::Azure::Gaming::EnvironmentVariableConfiguration::getGameServerConnectionInfo()
+{
+    return m_connectionInfo;
+}
+
 Microsoft::Azure::Gaming::JsonFileConfiguration::JsonFileConfiguration(const std::string &file_name) : Microsoft::Azure::Gaming::ConfigurationBase::ConfigurationBase()
 {
     std::ifstream is(file_name, std::ifstream::in);
@@ -142,6 +157,30 @@ Microsoft::Azure::Gaming::JsonFileConfiguration::JsonFileConfiguration(const std
                     m_ports[i.key().asCString()] = (*i).asCString();
                 }
             }
+
+            if (configFile.isMember("publicIpV4Address"))
+            {
+                m_ipv4Address = configFile["publicIpV4Address"].asString();
+            }
+
+            if (configFile.isMember("fullyQualifiedDomainName"))
+            {
+                m_domainName = configFile["fullyQualifiedDomainName"].asString();
+            }
+
+            if (configFile.isMember("gameServerConnectionInfo"))
+            {
+                Json::Value connectionInfo = configFile["gameServerConnectionInfo"];
+                Json::Value portsConfiguration = connectionInfo["gamePortsConfiguration"];
+                std::vector<GamePort> gamePorts;
+
+                for (Json::ValueIterator port = portsConfiguration.begin(); port != portsConfiguration.end(); ++port)
+                {
+                    gamePorts.emplace_back((*port)["name"].asString(), (*port)["serverListeningPort"].asInt(), (*port)["clientConnectionPort"].asInt());
+                }
+
+                m_connectionInfo = GameServerConnectionInfo(connectionInfo["publicIpV4Adress"].asString(), gamePorts); // publicIpV4Adress is a typo that exists in the gsdkConfig file...
+            }
         }
         else
         {
@@ -193,4 +232,19 @@ const std::unordered_map<std::string, std::string> &Microsoft::Azure::Gaming::Js
 const std::unordered_map<std::string, std::string> &Microsoft::Azure::Gaming::JsonFileConfiguration::getGamePorts()
 {
     return m_ports;
+}
+
+const std::string &Microsoft::Azure::Gaming::JsonFileConfiguration::getPublicIpV4Address()
+{
+    return m_ipv4Address;
+}
+
+const std::string &Microsoft::Azure::Gaming::JsonFileConfiguration::getFullyQualifiedDomainName()
+{
+    return m_domainName;
+}
+
+const Microsoft::Azure::Gaming::GameServerConnectionInfo &Microsoft::Azure::Gaming::JsonFileConfiguration::getGameServerConnectionInfo()
+{
+    return m_connectionInfo;
 }

--- a/cpp/cppsdk/gsdkConfig.h
+++ b/cpp/cppsdk/gsdkConfig.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <gsdk.h>
 #include <unordered_map>
 
 namespace Microsoft
@@ -21,6 +23,9 @@ namespace Microsoft
                 virtual const std::string &getRegion() = 0;
                 virtual const std::unordered_map<std::string, std::string> &getBuildMetadata() = 0;
                 virtual const std::unordered_map<std::string, std::string> &getGamePorts() = 0;
+                virtual const std::string &getPublicIpV4Address() = 0;
+                virtual const std::string &getFullyQualifiedDomainName() = 0;
+                virtual const GameServerConnectionInfo &getGameServerConnectionInfo() = 0;
                 virtual bool shouldLog() = 0;
                 virtual bool shouldHeartbeat() = 0;
 
@@ -65,6 +70,9 @@ namespace Microsoft
                 const std::unordered_map<std::string, std::string> &getGameCertificates();
                 const std::unordered_map<std::string, std::string> &getBuildMetadata();
                 const std::unordered_map<std::string, std::string> &getGamePorts();
+                const std::string &getPublicIpV4Address();
+                const std::string &getFullyQualifiedDomainName();
+                const GameServerConnectionInfo &getGameServerConnectionInfo();
 
             private:
                 std::string m_heartbeatEndpoint;
@@ -75,6 +83,9 @@ namespace Microsoft
                 std::unordered_map<std::string, std::string> m_gameCerts;
                 std::unordered_map<std::string, std::string> m_metadata;
                 std::unordered_map<std::string, std::string> m_ports;
+                std::string m_ipv4Address;
+                std::string m_domainName;
+                GameServerConnectionInfo m_connectionInfo;
             };
 
             class JsonFileConfiguration : public ConfigurationBase
@@ -90,6 +101,9 @@ namespace Microsoft
                 const std::unordered_map<std::string, std::string> &getGameCertificates();
                 const std::unordered_map<std::string, std::string> &getBuildMetadata();
                 const std::unordered_map<std::string, std::string> &getGamePorts();
+                const std::string &getPublicIpV4Address();
+                const std::string &getFullyQualifiedDomainName();
+                const GameServerConnectionInfo &getGameServerConnectionInfo();
 
             private:
                 std::string m_heartbeatEndpoint;
@@ -100,6 +114,9 @@ namespace Microsoft
                 std::unordered_map<std::string, std::string> m_gameCerts;
                 std::unordered_map<std::string, std::string> m_metadata;
                 std::unordered_map<std::string, std::string> m_ports;
+                std::string m_ipv4Address;
+                std::string m_domainName;
+                GameServerConnectionInfo m_connectionInfo;
             };
         }
     }

--- a/cpp/cppsdk/gsdkInternal.h
+++ b/cpp/cppsdk/gsdkInternal.h
@@ -148,6 +148,7 @@ namespace Microsoft
                 std::function<bool()> m_healthCallback;
                 std::function<void(const tm &)> m_maintenanceCallback;
 
+                GameServerConnectionInfo m_connectionInfo;
                 std::unordered_map<std::string, std::string> m_configSettings;
                 tm m_cachedScheduledMaintenance;
 

--- a/cpp/unittests/TestConfig.cpp
+++ b/cpp/unittests/TestConfig.cpp
@@ -11,7 +11,10 @@ Microsoft::Azure::Gaming::TestConfig::TestConfig(   const std::string & heartbea
                                                     const std::string & buildId,
                                                     const std::string & region,
                                                     const std::unordered_map<std::string, std::string> & metadata,
-                                                    const std::unordered_map<std::string, std::string> & ports)
+                                                    const std::unordered_map<std::string, std::string> & ports,
+                                                    const std::string & ipv4Address,
+                                                    const std::string & domainName,
+                                                    const GameServerConnectionInfo & connectionInfo)
 {
     m_heartbeatEndpoint = heartbeatEndpoint;
     m_serverId = serverId;
@@ -24,6 +27,9 @@ Microsoft::Azure::Gaming::TestConfig::TestConfig(   const std::string & heartbea
     m_region = region;
     m_metadata = metadata;
     m_ports = ports;
+    m_ipv4Address = ipv4Address;
+    m_domainName = domainName;
+    m_connectionInfo = connectionInfo;
 }
 
 const std::string &Microsoft::Azure::Gaming::TestConfig::getHeartbeatEndpoint()
@@ -89,4 +95,19 @@ const std::unordered_map<std::string, std::string> &Microsoft::Azure::Gaming::Te
 const std::unordered_map<std::string, std::string> &Microsoft::Azure::Gaming::TestConfig::getGamePorts()
 {
     return m_ports;
+}
+
+const std::string &Microsoft::Azure::Gaming::TestConfig::getPublicIpV4Address()
+{
+    return m_ipv4Address;
+}
+
+const std::string &Microsoft::Azure::Gaming::TestConfig::getFullyQualifiedDomainName()
+{
+    return m_domainName;
+}
+
+const Microsoft::Azure::Gaming::GameServerConnectionInfo &Microsoft::Azure::Gaming::TestConfig::getGameServerConnectionInfo()
+{
+    return m_connectionInfo;
 }

--- a/cpp/unittests/TestConfig.h
+++ b/cpp/unittests/TestConfig.h
@@ -21,7 +21,10 @@ namespace Microsoft
                             const std::string & buildId = std::string(),
                             const std::string & region = std::string(),
                             const std::unordered_map<std::string, std::string> & metadata = std::unordered_map<std::string, std::string>(),
-                            const std::unordered_map<std::string, std::string> & ports = std::unordered_map<std::string, std::string>());
+                            const std::unordered_map<std::string, std::string> & ports = std::unordered_map<std::string, std::string>(),
+                            const std::string & ipv4Address = std::string() = std::string(),
+                            const std::string & domainName = std::string() = std::string(),
+                            const GameServerConnectionInfo & connectionInfo = GameServerConnectionInfo());
 
                 const std::string &getHeartbeatEndpoint();
                 const std::string &getServerId();
@@ -34,6 +37,9 @@ namespace Microsoft
                 const std::string &getRegion();
                 const std::unordered_map<std::string, std::string> &getBuildMetadata();
                 const std::unordered_map<std::string, std::string> &getGamePorts();
+                const std::string &getPublicIpV4Address();
+                const std::string &getFullyQualifiedDomainName();
+                const GameServerConnectionInfo &getGameServerConnectionInfo();
                 bool shouldLog();
                 bool shouldHeartbeat();
 
@@ -49,6 +55,9 @@ namespace Microsoft
                 std::string m_titleId;
                 std::string m_buildId;
                 std::string m_region;
+                std::string m_ipv4Address;
+                std::string m_domainName;
+                GameServerConnectionInfo m_connectionInfo;
             };
         }
     }


### PR DESCRIPTION
The C# SDK supports querying these properties from the `gsdkConfig.json` file already -- so this aims to bring the CPP SDK inline with the C# version. I tried to keep things one-to-one where possible and followed the code style already set for the CPP SDK.

Please note that this doesn't add any new tests for verifying the added functionality, but I have tested and deployed my changes to Server 2.0 and performed quick tests there. Ideally, a maintainer would implement the necessary tests though. :)