### PR TITLE
c++ change for thread safety

### DIFF
--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
@@ -1,4 +1,6 @@
-﻿#if ENABLE_PLAYFABSERVER_API
+﻿using System.Collections.Concurrent;
+
+#if ENABLE_PLAYFABSERVER_API
 namespace PlayFab
 {
     using System;
@@ -96,7 +98,7 @@ namespace PlayFab
 
         private static IDictionary<string, string> CreateConfigMap(GSDKConfiguration localConfig)
         {
-            var finalConfig = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var finalConfig = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (KeyValuePair<string, string> certEntry in localConfig.GameCertificates)
             {

--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Concurrent;
-
+﻿
 #if ENABLE_PLAYFABSERVER_API
 namespace PlayFab
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;

--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -475,7 +475,9 @@ namespace Microsoft
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";
 
-                const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();
+				std::lock_guard<std::mutex> lock(GSDKInternal::get().m_configMutex);
+
+                const std::unordered_map<std::string, std::string> config = GSDKInternal::get().m_configSettings;
                 auto it = config.find(GSDK::LOG_FOLDER_KEY);
 
                 if (it == config.end())
@@ -493,7 +495,10 @@ namespace Microsoft
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";
 
-                const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();
+				std::lock_guard<std::mutex> lock(GSDKInternal::get().m_configMutex);
+
+				const std::unordered_map<std::string, std::string> config = GSDKInternal::get().m_configSettings;
+
                 auto it = config.find(GSDK::SHARED_CONTENT_FOLDER_KEY);
 
                 if (it == config.end())

--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -436,7 +436,7 @@ namespace Microsoft
                 return GSDKInternal::get().m_connectionInfo;
             }
 
-            const std::unordered_map<std::string, std::string>& GSDK::getConfigSettings()
+            const std::unordered_map<std::string, std::string> GSDK::getConfigSettings()
             {
 				std::lock_guard<std::mutex> lock(GSDKInternal::get().m_configMutex);
                 return GSDKInternal::get().m_configSettings;
@@ -470,12 +470,12 @@ namespace Microsoft
                 return 0;
             }
 
-            const std::string& GSDK::getLogsDirectory()
+            const std::string GSDK::getLogsDirectory()
             {
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";
 
-                const std::unordered_map<std::string, std::string>& config = GSDK::getConfigSettings();
+                const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();
                 auto it = config.find(GSDK::LOG_FOLDER_KEY);
 
                 if (it == config.end())
@@ -484,16 +484,16 @@ namespace Microsoft
                 }
                 else
                 {
-                    return it->second;
+					return it->second;
                 }
             }
 
-            const std::string& GSDK::getSharedContentDirectory()
+            const std::string GSDK::getSharedContentDirectory()
             {
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";
 
-                const std::unordered_map<std::string, std::string>& config = GSDK::getConfigSettings();
+                const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();
                 auto it = config.find(GSDK::SHARED_CONTENT_FOLDER_KEY);
 
                 if (it == config.end())

--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -289,12 +289,14 @@ namespace Microsoft
                 try {
                     if (heartbeatResponse.isMember("sessionConfig"))
                     {
+						std::unordered_map<std::string, std::string> tempConfig = std::unordered_map<std::string, std::string>(m_configSettings);
+
                         Json::Value sessionConfig = heartbeatResponse["sessionConfig"];
                         for (Json::ValueIterator i = sessionConfig.begin(); i != sessionConfig.end(); ++i)
                         {
                             if ((*i).isString())
                             {
-                                m_configSettings[i.key().asCString()] = (*i).asCString();
+								tempConfig[i.key().asCString()] = (*i).asCString();
                             }
                         }
 
@@ -316,10 +318,12 @@ namespace Microsoft
                             {
                                 if ((*i).isString())
                                 {
-                                    m_configSettings[i.key().asCString()] = (*i).asCString();
+									tempConfig[i.key().asCString()] = (*i).asCString();
                                 }
                             }
                         }
+
+						m_configSettings = std::unordered_map<std::string, std::string>(tempConfig);
                     }
 
                     if (heartbeatResponse.isMember("nextScheduledMaintenanceUtc"))

--- a/cpp/cppsdk/gsdk.h
+++ b/cpp/cppsdk/gsdk.h
@@ -96,7 +96,7 @@ namespace Microsoft
 
                 /// <summary>Returns all configuration settings</summary>
                 /// <returns>unordered map of string key:value configuration setting values</returns>
-                static const std::unordered_map<std::string, std::string> &getConfigSettings();
+                static const std::unordered_map<std::string, std::string> getConfigSettings();
 
                 /// <summary>Kicks off communication threads, heartbeats, etc.  Called implicitly by ReadyForPlayers if not called beforehand.</summary>
                 /// <param name="debugLogs">Enables outputting additional logs to the GSDK log file.</param>
@@ -119,10 +119,10 @@ namespace Microsoft
                 static unsigned int logMessage(const std::string &message);
 
                 /// <summary>Returns a path to the directory where logs will be mapped to the VM host</summary>
-                static const std::string &getLogsDirectory();
+                static const std::string getLogsDirectory();
 
                 /// <summary>Returns a path to the directory shared by all game servers to cache data.</summary>
-                static const std::string &getSharedContentDirectory();
+                static const std::string getSharedContentDirectory();
 
                 /// <summary>After allocation, returns a list of the initial players that have access to this game server, used by PlayFab's Matchmaking offering</summary>
                 static const std::vector<std::string> &getInitialPlayers();

--- a/cpp/cppsdk/gsdkInternal.h
+++ b/cpp/cppsdk/gsdkInternal.h
@@ -197,6 +197,7 @@ namespace Microsoft
                 // These two methods are used for unit testing
                 std::string encodeHeartbeatRequest();
                 void decodeHeartbeatResponse(const std::string &responseJson);
+				std::mutex m_configMutex;
 
                 std::tm parseDate(const std::string &dateStr);
                 void setState(GameState state);

--- a/cpp/unittests/gsdkTests.cpp
+++ b/cpp/unittests/gsdkTests.cpp
@@ -48,7 +48,7 @@ namespace Microsoft
                     ports["port2"] = "2222";
                     GSDKInternal::testConfiguration = std::make_unique<TestConfig>(heartbeatEndpoint, serverId, logFolder, sharedContentFolder, certFolder, gameCerts, titleId, buildId, region, metadata, ports);
                     GSDK::start();
-                    const std::unordered_map<std::string, std::string> &config = GSDK::getConfigSettings();
+                    const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();
                     Assert::AreEqual(heartbeatEndpoint, config.at("gsmsBaseUrl"), L"Ensuring heartbeat endpoint was set.");
                     Assert::AreEqual(serverId, config.at("instanceId"), L"Ensuring server id was set.");
                     Assert::AreEqual(logFolder, config.at("logFolder"), L"Ensuring log folder was set.");
@@ -161,7 +161,7 @@ namespace Microsoft
                     GSDKInternal::m_instance->decodeHeartbeatResponse(responseJson);
 
                     // Test heartbeat response handled correctly
-                    const std::unordered_map<std::string, std::string> &config = GSDK::getConfigSettings();
+                    const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();
                     Assert::IsTrue("eca7e870-da2e-45f9-bb66-30d89064313a" == config.at("sessionId"), L"Verify session id was captured from the heartbeat.");
                     Assert::IsTrue("OreoCookie" == config.at("sessionCookie"), L"Verify session cookie was captured from the heartbeat.");
                     Assert::IsTrue(1523552310LL == maintenanceTime, L"Verify maintenance callback with correct time was called.");
@@ -274,7 +274,7 @@ namespace Microsoft
                     GSDKInternal::m_instance->decodeHeartbeatResponse(responseJson);
 
                     // Test heartbeat response handled correctly
-                    const std::unordered_map<std::string, std::string> &config = GSDK::getConfigSettings();
+                    const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();
                     Assert::AreEqual(std::string("testValue"), config.at("testKey"), L"Ensuring session metadata was set.");
                 }
 

--- a/upgradeguide200219.md
+++ b/upgradeguide200219.md
@@ -1,0 +1,43 @@
+---
+title: Upgrade guide for 0.7.190918 -> 0.7.200220
+author: gufabre
+description: Description of breaking changes of new cpp nuget release.
+ms.author: gufabre
+ms.date: 02/19/2020
+ms.topic: article
+ms.prod: playfab
+keywords: playfab, development, release, apis, features
+ms.localizationpriority: medium
+---
+
+# Upgrade guide for 0.7.190918 -> 0.7.200220
+
+The 0.7.200220 release of the GSDK for C++ contains breaking changes. The primary change in this update is provide thread safety. Previous implementations allowed a thread to alter a dictionary while another thread read it which caused errors and raised exceptions. This topic provides detailed instructions on the steps you must take to update your code when you update to current release.
+
+The PR contains a detailed explanation of the changes: [c++ change for thread safety #43](https://github.com/PlayFab/gsdk/pull/43/)
+
+Most customers are only affected by 3 very minor breaking changes in this release. Nearly all customers will need to change 1 or 2 lines of code, but very few customers might need to change more. The upgrade guide below cover all of the possible changes required for even the most obscure breaking changes.
+
+## Upgrade instructions - Affects most/all customers
+
+
+The following methods have been updated to return an object instead of a reference:
+1. `GSDK::getConfigSettings()`
+2. `GSDK::getLogsDirectory()`
+3. `GSDK::getSharedContentDirectory()`
+
+* You must update your code as follows to accept the returned object:
+
+    `GSDK::getConfigSettings()`
+    * Old: ```const std::unordered_map<std::string, std::string>& config = GSDK::getConfigSettings();```
+    * New: ```const std::unordered_map<std::string, std::string> config = GSDK::getConfigSettings();```
+
+    `GSDK::getLogsDirectory()`
+    * Old: ```const std::string& logsDirectory = GSDK::getLogsDirectory();```
+    * New: ```const std::string logsDirectory = GSDK::getLogsDirectory();```
+
+    `GSDK::getSharedContentDirectory()`
+    * Old: ```const std::string& sharedContentDirectory = GSDK::getSharedContentDirectory();```
+    * New: ```const std::string sharedContentDirectory = GSDK::getSharedContentDirectory();```
+
+We apologize that while trivial, these changes were necessary in order to ensure thread safety.


### PR DESCRIPTION
to achieve thread safety in c++ a copy of the dictionary is modified, and then this copy is assigned to the original object.