### PR TITLE
Fix/heartbeat vanishing

### DIFF
--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
@@ -7,8 +7,34 @@ namespace PlayFab
 
     public class PlayFabMultiplayerAgentView : MonoBehaviour
     {
+		/// <summary>
+		/// Static reference to the current active instance of the PlayFabMultiplayerAgentView.
+		/// </summary>
+		public static PlayFabMultiplayerAgentView current { get; private set; };
+		
         private float _timer;
 
+		/// <summary>
+		/// Awake constructor
+		/// </summary>
+		private void Awake()
+		{
+			Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView awake ");
+			// Check if the static instance already contains a refernce:
+			if (current)
+			{
+				// Destroy this instance since we only ever need one PlayFabMultiplayerAgentView
+				Destroy(gameObject);
+				return;
+			}
+			else
+			{
+				// Need to keep this game object alive through scene changes.
+				DontDestroyOnLoad(this);
+				current = this;
+			}
+		}
+		
         private void LateUpdate()
         {
             if (PlayFabMultiplayerAgentAPI.CurrentState == null)
@@ -57,5 +83,13 @@ namespace PlayFab
                 StartCoroutine(PlayFabMultiplayerAgentAPI.SendHeartBeatRequest());
             }
         }
+		
+		/// <summary>
+		/// Called when gameobject is destroyed
+		/// </summary>
+		private void OnDestroy()
+		{
+			Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView destroyed ");
+		}
     }
 }

--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
@@ -7,34 +7,34 @@ namespace PlayFab
 
     public class PlayFabMultiplayerAgentView : MonoBehaviour
     {
-		/// <summary>
-		/// Static reference to the current active instance of the PlayFabMultiplayerAgentView.
-		/// </summary>
-		public static PlayFabMultiplayerAgentView current { get; private set; };
-		
+        /// <summary>
+        /// Static reference to the current active instance of the PlayFabMultiplayerAgentView.
+        /// </summary>
+        public static PlayFabMultiplayerAgentView current { get; private set; };
+        
         private float _timer;
 
-		/// <summary>
-		/// Awake constructor
-		/// </summary>
-		private void Awake()
-		{
-			Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView awake ");
-			// Check if the static instance already contains a refernce:
-			if (current)
-			{
-				// Destroy this instance since we only ever need one PlayFabMultiplayerAgentView
-				Destroy(gameObject);
-				return;
-			}
-			else
-			{
-				// Need to keep this game object alive through scene changes.
-				DontDestroyOnLoad(this);
-				current = this;
-			}
-		}
-		
+        /// <summary>
+        /// Awake constructor
+        /// </summary>
+        private void Awake()
+        {
+            Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView awake ");
+            // Check if the static instance already contains a refernce:
+            if (current)
+            {
+                // Destroy this instance since we only ever need one PlayFabMultiplayerAgentView
+                Destroy(gameObject);
+                return;
+            }
+            else
+            {
+                // Need to keep this game object alive through scene changes.
+                DontDestroyOnLoad(this);
+                current = this;
+            }
+        }
+        
         private void LateUpdate()
         {
             if (PlayFabMultiplayerAgentAPI.CurrentState == null)
@@ -83,13 +83,13 @@ namespace PlayFab
                 StartCoroutine(PlayFabMultiplayerAgentAPI.SendHeartBeatRequest());
             }
         }
-		
-		/// <summary>
-		/// Called when gameobject is destroyed
-		/// </summary>
-		private void OnDestroy()
-		{
-			Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView destroyed ");
-		}
+        
+        /// <summary>
+        /// Called when gameobject is destroyed
+        /// </summary>
+        private void OnDestroy()
+        {
+            Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView destroyed ");
+        }
     }
 }

--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
@@ -10,7 +10,7 @@ namespace PlayFab
         /// <summary>
         /// Static reference to the current active instance of the PlayFabMultiplayerAgentView.
         /// </summary>
-        public static PlayFabMultiplayerAgentView current { get; private set; };
+        public static PlayFabMultiplayerAgentView Current { get; private set; } = null;
         
         private float _timer;
 
@@ -19,9 +19,9 @@ namespace PlayFab
         /// </summary>
         private void Awake()
         {
-            Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView awake ");
-            // Check if the static instance already contains a refernce:
-            if (current)
+            Debug.Log($"{Time.fixedTime} {nameof(PlayFabMultiplayerAgentView)} awake");
+            // Check if the static instance already contains a reference:
+            if(Current != null)
             {
                 // Destroy this instance since we only ever need one PlayFabMultiplayerAgentView
                 Destroy(gameObject);
@@ -89,7 +89,7 @@ namespace PlayFab
         /// </summary>
         private void OnDestroy()
         {
-            Debug.Log($"{Time.fixedTime} PlayFabMultiplayerAgentView destroyed ");
+            Debug.Log($"{Time.fixedTime} {nameof(PlayFabMultiplayerAgentView)} destroyed");
         }
     }
 }

--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
@@ -31,7 +31,7 @@ namespace PlayFab
             {
                 // Need to keep this game object alive through scene changes.
                 DontDestroyOnLoad(this);
-                current = this;
+                Current = this;
             }
         }
         


### PR DESCRIPTION
This addresses the problems discussed in issue #49.

By adding a singleton design to the PlayFabMultiplayerAgentView as well as applying DontDestroyOnLoad on the Component we can make sure that the PlayFabMultiplayerAgentView will always be unique and persist over all scene changes until manually destroyed.
Comments and criticism always welcome.

Note: The code changes have yet to be tested thoroughly.