### PR TITLE
Add empty check of heartbeats base url

### DIFF
--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
@@ -169,7 +169,7 @@ namespace PlayFab
         public static IEnumerator SendHeartBeatRequest()
         {
             string payload = _jsonInstance.SerializeObject(CurrentState);
-            if (string.IsNullOrEmpty(payload))
+            if (string.IsNullOrEmpty(payload) || string.IsNullOrEmpty(_baseUrl))
             {
                 yield break;
             }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing section on Readme.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:

When the client is initializing there is an interval of time where the _baseUrl is and empty string but the coroutine SendHeartBeatRequest gets called though.

In that interval, the client makes a web request with an empty string as url which gives an "curl error 3 url malformed" error.

This check avoid that situation.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility