### PR TITLE
Java: Keep heartbeat thread alive

### DIFF
--- a/java/gameserverSDK/src/main/java/com/microsoft/azure/gaming/HeartbeatThread.java
+++ b/java/gameserverSDK/src/main/java/com/microsoft/azure/gaming/HeartbeatThread.java
@@ -227,10 +227,14 @@ class HeartbeatThread implements Runnable {
 
                 // Perform the operation that the server requested
                 PerformOperation(sessionInfo.getOperation());
-            } catch (RetryException | ExecutionException e) {
-                Logger.Instance().LogError("Checked exception occurred when sending a heartbeat to the agent", e);
+            } catch (RetryException e) {
+                Logger.Instance().LogError("Exhausted all retry attempts when trying to send heartbeat to the agent.", e);
             } catch (Exception e) {
                 Logger.Instance().LogError("Unexpected exception occurred when sending a heartbeat to the agent.  Terminating process.", e);
+                Runnable temp = shutdownCallback;
+                if (temp != null) {
+                    temp.run();
+                }
                 System.exit(1);
             }
         }

--- a/java/gameserverSDK/src/main/java/com/microsoft/azure/gaming/HeartbeatThread.java
+++ b/java/gameserverSDK/src/main/java/com/microsoft/azure/gaming/HeartbeatThread.java
@@ -33,8 +33,6 @@ import java.util.function.Supplier;
  * of the GSDK.
  */
 class HeartbeatThread implements Runnable {
-    private String agentEndpoint;
-    private String serverId;
     private SessionHostStatus serverState;
     private List<ConnectedPlayer> connectedPlayers;
     private Map<String, String> configSettings;
@@ -46,6 +44,7 @@ class HeartbeatThread implements Runnable {
     private ZonedDateTime lastScheduledMaintenanceUtc;
     private final Semaphore transitionToActive = new Semaphore(0);
     private final Semaphore signalHeartbeat = new Semaphore(0);
+    private final URI agentUri;
 
     private final int MAXIMUM_NUM_HEARTBEAT_RETRIES = 8;
     private final int WAIT_TIME_BETWEEN_HEARTBEAT_RETRIES_MILLISECONDS = 1000;
@@ -70,8 +69,8 @@ class HeartbeatThread implements Runnable {
 
         config.validate();
 
-        this.agentEndpoint = config.getHeartbeatEndpoint();
-        this.serverId = config.getServerId();
+        String agentEndpoint = config.getHeartbeatEndpoint();
+        String serverId = config.getServerId();
 
         configSettings = Collections.synchronizedMap(new HashMap<String, String>());
         configSettings.putAll(config.getBuildMetadata());
@@ -84,12 +83,18 @@ class HeartbeatThread implements Runnable {
         configSettings.put(GameserverSDK.BUILD_ID_KEY, config.getBuildId());
         configSettings.put(GameserverSDK.REGION_KEY, config.getRegion());
 
-        Logger.Instance().Log("VM Agent Endpoint: " + this.agentEndpoint);
-        Logger.Instance().Log("Instance Id: " + this.serverId);
+        Logger.Instance().Log("VM Agent Endpoint: " + agentEndpoint);
+        Logger.Instance().Log("Instance Id: " + serverId);
 
         // Send an initial heartbeat here in the constructor so that we can fail
         // quickly if the Agent is unreachable.
         try {
+            this.agentUri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost(agentEndpoint)
+                    .setPath("/v1/sessionHosts/" + serverId)
+                    .build();
+
             SessionHostHeartbeatInfo heartbeatInfo = this.sendHeartbeat(this.getState());
             this.heartbeatInterval = heartbeatInfo.getNextHeartbeatIntervalMs();
             PerformOperation(heartbeatInfo.getOperation());
@@ -222,8 +227,11 @@ class HeartbeatThread implements Runnable {
 
                 // Perform the operation that the server requested
                 PerformOperation(sessionInfo.getOperation());
+            } catch (RetryException | ExecutionException e) {
+                Logger.Instance().LogError("Checked exception occurred when sending a heartbeat to the agent", e);
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                Logger.Instance().LogError("Unexpected exception occurred when sending a heartbeat to the agent.  Terminating process.", e);
+                System.exit(1);
             }
         }
     }
@@ -237,12 +245,7 @@ class HeartbeatThread implements Runnable {
      * @throws ExecutionException If an unexpected exception is raised by one of the retry attempts then that exception will
      * be included as the 'cause' in an ExceutionException.
      */
-    private SessionHostHeartbeatInfo sendHeartbeat(SessionHostStatus currentState) throws URISyntaxException, RetryException, ExecutionException {
-        URI uri = new URIBuilder()
-                .setScheme("http")
-                .setHost(this.agentEndpoint)
-                .setPath("/v1/sessionHosts/" + this.serverId)
-                .build();
+    private SessionHostHeartbeatInfo sendHeartbeat(SessionHostStatus currentState) throws RetryException, ExecutionException {
 
         Gson gson = new Gson();
         Retryer<SessionHostHeartbeatInfo> retryer = RetryerBuilder.<SessionHostHeartbeatInfo>newBuilder()
@@ -264,7 +267,7 @@ class HeartbeatThread implements Runnable {
                 heartbeatInfo.setCurrentGameHealth(callback.get());
             }
 
-            heartbeatInfo = Request.Patch(uri)
+            heartbeatInfo = Request.Patch(agentUri)
                     .bodyString(gson.toJson(heartbeatInfo), ContentType.APPLICATION_JSON)
                     .connectTimeout(HEARTBEAT_TIMEOUT_MILLISECONDS)
                     .socketTimeout(HEARTBEAT_TIMEOUT_MILLISECONDS)

--- a/java/gameserverSDK/src/main/java/com/microsoft/azure/gaming/Logger.java
+++ b/java/gameserverSDK/src/main/java/com/microsoft/azure/gaming/Logger.java
@@ -70,7 +70,7 @@ class Logger {
 
     protected void LogError(String message)
     {
-        this.Log("ERROR: " + message);
+        this.LogError(message, null);
     }
 
     protected void LogWarning(String message){
@@ -79,11 +79,23 @@ class Logger {
 
     protected void LogError(Exception ex)
     {
+        this.LogError("", ex);
+    }
+
+    protected void LogError(String message, Exception ex)
+    {
         try(BufferedOutputStream bos = new BufferedOutputStream(
-            Files.newOutputStream(this.logFile, CREATE, APPEND));
+                Files.newOutputStream(this.logFile, CREATE, APPEND));
             PrintWriter out = new PrintWriter(bos))
         {
-            ex.printStackTrace(out);
+            if (message != null && !message.equals(""))
+            {
+                out.println("ERROR: " + message);
+            }
+            if (ex != null)
+            {
+                ex.printStackTrace(out);
+            }
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Previously, if something went wrong on the heartbeat thread we would
simply convert the checked exception into a runtime exception and then
throw it.  That would ultimately terminate our heartbeat thread, but
the game server process would have no idea.  The end result is that
game servers could end up stuck in the `readyForPlayers()` method
forever.

This approach catches only the exceptions that we expect, logs them and
then keeps going.  If we encounter an exception that we can't handle
then we log it and then end the process since we can no longer safely
reason about the state of our application.

Lastly, I shuffled around the location where we build the URI for
the agent endpoint out of the `sendHeartbeat` method so that we didn't
have to deal with the `URISyntaxException` in our main loop.  I figure
that since that URI doesn't change with time, then we should be able
to just build it once.

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing section on Readme.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility