### PR TITLE
Fix for std::filesystem and VS2019

### DIFF
--- a/cpp/cppsdk/gsdkUtils.cpp
+++ b/cpp/cppsdk/gsdkUtils.cpp
@@ -5,7 +5,8 @@
 #include "gsdkInternal.h"
 
 #ifdef GSDK_WINDOWS
-#include "filesystem"
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include "experimental/filesystem"
 #include "process.h"
 #endif
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing section on Readme.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:
This forces the use of the experimental version of the filesystem header and silences the deprecation warning. 

**Special notes for your reviewer**:
Temp fix that works with both VS2017 and VS2019, however we should discuss a better fix for both (will add in comment below).

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility