### PR TITLE
Fixes compiler errors

### DIFF
--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentView.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if ENABLE_PLAYFABSERVER_API
+
+using System;
 
 namespace PlayFab
 {
@@ -93,3 +95,5 @@ namespace PlayFab
         }
     }
 }
+
+#endif


### PR DESCRIPTION
if a project does not define ENABLE_PLAYFABSERVER_API. 
PlayFabMultiplayerAgentView.cs does not compile.

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing section on Readme.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:

This PR adds conditional compilation of PlayFabMultiplayerAgentView.cs to avoid the errors.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility