### PR TITLE
[WIP] Refactoring GSDKInternal singleton to fix crash on linux server shutdown

### DIFF
--- a/cpp/cppsdk/gsdk.h
+++ b/cpp/cppsdk/gsdk.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <functional>
 #include <exception>
+#include <stdexcept>
 #include <vector>
 
 namespace Microsoft
@@ -100,7 +101,10 @@ namespace Microsoft
 
                 /// <summary>Kicks off communication threads, heartbeats, etc.  Called implicitly by ReadyForPlayers if not called beforehand.</summary>
                 /// <param name="debugLogs">Enables outputting additional logs to the GSDK log file.</param>
-                static void start(bool debugLogs = false);
+                static bool start(bool debugLogs = false);
+
+                /// <summary>Halts communication threads, heartbeats, etc.  Call this before shutting down your executable.</summary>
+                static void stop();
 
                 /// <summary>Tells the Xcloud service information on who is connected.</summary>
                 /// <param name="currentlyConnectedPlayers"></param>

--- a/cpp/cppsdk/gsdkConfig.h
+++ b/cpp/cppsdk/gsdkConfig.h
@@ -12,6 +12,8 @@ namespace Microsoft
             class Configuration
             {
             public:
+                virtual ~Configuration() = default;
+
                 virtual const std::string &getHeartbeatEndpoint() = 0;
                 virtual const std::string &getServerId() = 0;
                 virtual const std::string &getLogFolder() = 0;
@@ -43,6 +45,7 @@ namespace Microsoft
             {
             public:
                 ConfigurationBase();
+                virtual ~ConfigurationBase() = default;
 
                 const std::string &getTitleId();
                 const std::string &getBuildId();
@@ -61,6 +64,7 @@ namespace Microsoft
             {
             public:
                 EnvironmentVariableConfiguration();
+                virtual ~EnvironmentVariableConfiguration() = default;
 
                 const std::string &getHeartbeatEndpoint();
                 const std::string &getServerId();
@@ -92,6 +96,7 @@ namespace Microsoft
             {
             public:
                 JsonFileConfiguration(const std::string &file_name);
+                virtual ~JsonFileConfiguration() = default;
 
                 const std::string &getHeartbeatEndpoint();
                 const std::string &getServerId();

--- a/cpp/cppsdk/gsdkInternal.h
+++ b/cpp/cppsdk/gsdkInternal.h
@@ -138,6 +138,7 @@ namespace Microsoft
                     GAME_OPERATIONS(MAKE_OPERATION_MAP)
                 };
 
+                bool m_isInitialized;
                 std::string m_agentEntpoint;
                 HeartbeatRequest m_heartbeatRequest;
                 std::string m_sessionCookie;
@@ -176,8 +177,7 @@ namespace Microsoft
 
                 std::vector<std::string> m_initialPlayers;
 
-                static std::unique_ptr<GSDKInternal> m_instance;
-                static std::mutex m_gsdkInitMutex;
+                static GSDKInternal *m_instance;
 
                 static volatile long long m_exitStatus;
                 static std::mutex m_logLock;
@@ -189,7 +189,10 @@ namespace Microsoft
                 
                 static bool m_debug;
 
+                bool init();
+                void dispose();
                 void startLog();
+                void stopLog();
                 void resetCurl();
                 void sendHeartbeat();
                 void receiveHeartbeatResponse();
@@ -203,7 +206,7 @@ namespace Microsoft
                 void setState(GameState state);
                 void setConnectedPlayers(const std::vector<ConnectedPlayer> &currentConnectedPlayers);
 
-                static GSDKInternal &get();
+                static GSDKInternal *get();
                 static std::unique_ptr<Configuration> testConfiguration; // may be overriden by unit tests
             };
 

--- a/cpp/cppsdk/include/playfab/PlayFabBaseModel.h
+++ b/cpp/cppsdk/include/playfab/PlayFabBaseModel.h
@@ -78,7 +78,7 @@ namespace PlayFab
     // Utilities for [de]serializing time_t to/from json
     inline void ToJsonUtilT(const time_t input, Json::Value& output)
     {
-        input; // vs is stupid
+        (void)input; // vs is stupid
         struct tm timeInfo;
 #ifdef GSDK_WINDOWS
         gmtime_s(&timeInfo, &input);


### PR DESCRIPTION
We are currently evaluating PlayFab hosted game servers, built in Unreal Engine 4.26, running in Linux (Ubuntu docker image). After getting the GSDK integrated and working with our linux server builds we noticed a consistent crash on server shutdown. After some digging it appears to an issue with a mutex getting disposed of before it's needed for heartbeat thread joining logic:

![GSDK_Thread](https://user-images.githubusercontent.com/3753542/110688613-9c29e180-8196-11eb-818b-d1fd8d42abe1.PNG)

The exception is happening when trying to take the m_receivedDataMutex in GSDKInternal::curlReceiveData:
https://github.com/PlayFab/gsdk/blob/master/cpp/cppsdk/gsdk.cpp#L175

I think since we are in the GSDKInternal destructor (trying to join on the heartbeat thread) the mutex has already been cleaned up. 

To have more control over when the start and stop of the heartbeat thread and when the corresponding threading primitives are allocated/deallocated I did the following refactor:
* Added init() and dispose() methods to GSDKInternal that now do the setup and teardown work the constructor and destructor did before
* GSDKInternal::get() now just returns a plain c++ pointer to the GSDKInternal singleton (can now be null)
* GSDK::start() now explicitly allocates the GSDKInternal singleton and calls GSDKInternal::init()
* Added a new GSDK::stop() that explicitly tears down the GSDKInternal singleton
    * Our UE4 plugin calls GSDK::stop() at module shutdown time
* Fixed up all GSDK public functions (readyForPlayers, getConfigSettings, etc) to handle singleton being null (if GSDK::start() hasn't been called yet)
* Also fixed some compiler warnings I was seeing with clang (see minor config class virtual destructors + unref'd var change)

Generally speaking, in our game code we prefer to have singleton systems like this have explicit teardown calls rather than destructors getting called on shutdown do cleanup (especially when it comes to things like threads). But since this SDK is also used by other clients it's possible this kind of explicit teardown isn't desired. That said it wasn't clear to me how to make this heartbeat thread join work while guaranteeing that the dependent mutex hadn't been cleaned up yet with out an explicit dispose call. 

For now we have something that works for us on our end, but open to suggestions on this PR if you folks have a suggestion as to how to better fix this.

Cheers,
Brendan Walker
Polyarc | Engineer
