### PR TITLE
Fixed error in linux dockerfile, so that the unreal plugin can write the log file

### DIFF
--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -286,4 +286,3 @@ su ue -c ./<projectname>Server.sh
 Make sure that the line endings in the startup&#46;sh file are LF (\\n) and not CRLF (\\r\\n).
 
 Thank you to [narthur157](https://github.com/narthur157) for his amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4), which this Dockerfile is based on.
-Thank you to [narthur157](https://github.com/narthur157) for his amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4), which this Dockerfile is based on.

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -264,8 +264,6 @@ During testing the following Dockerfile + startup.sh script worked excellent wit
 ```Dockerfile
 FROM ubuntu:18.04
 
-RUN apt install -y jq
-
 # Unreal refuses to run as root user, so we must create a user to run as
 # Docker uses root by default
 RUN useradd --system ue
@@ -282,8 +280,7 @@ CMD ./startup.sh
 
 ### startup&#46;sh bash script:
 ```bash
-logFolderName=$(cat $GSDK_CONFIG_FOLDER | jq .logFolder)
-chown -R ue.ue $logFolderName
+chown -R ue.ue $PF_SERVER_LOG_DIRECTORY
 su ue -c ./<projectname>Server.sh
 ```
 Make sure that the line endings in the startup&#46;sh file are LF (\\n) and not CRLF (\\r\\n).

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -283,7 +283,7 @@ CMD ./startup.sh
 ### startup&#46;sh bash script:
 ```bash
 logFolderName=$(cat $GSDK_CONFIG_FOLDER | jq .logFolder)
-chown -R ue.ue $logfolderName
+chown -R ue.ue $logFolderName
 su ue -c ./<projectname>Server.sh
 ```
 Make sure that the line endings in the startup&#46;sh file are LF (\\n) and not CRLF (\\r\\n).

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -258,9 +258,13 @@ In container-based mode use \<mount folder\>\\\<root folder\>\\Binaries\\Win64\\
 **If you use the executable in the root folder, the server will fail to initialize with the Playfab system.**
 
 ## Setting up a Linux Dedicated Server on Playfab
-During testing the following Dockerfile worked excellent with the Playfab Linux VM:
+During testing the following Dockerfile + startup.sh script worked excellent with the Playfab Linux VM:
+
+### The Dockerfile:
 ```Dockerfile
 FROM ubuntu:18.04
+
+RUN apt install -y jq
 
 # Unreal refuses to run as root user, so we must create a user to run as
 # Docker uses root by default
@@ -272,6 +276,17 @@ EXPOSE 7777/udp
 WORKDIR /server
 
 COPY --chown=ue:ue . /server
-CMD ./<projectname>Server.sh
+USER root
+CMD ./startup.sh
 ```
-Thank you to [narthur157](https://github.com/narthur157) for this amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4).
+
+### startup&#46;sh bash script:
+```bash
+logFolderName=$(cat $GSDK_CONFIG_FOLDER | jq .logFolder)
+chown -R ue.ue $logfolderName
+su ue -c ./<projectname>Server.sh
+```
+Make sure that the line endings in the startup&#46;sh file are LF (\\n) and not CRLF (\\r\\n).
+
+Thank you to [narthur157](https://github.com/narthur157) for his amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4), which this Dockerfile is based on.
+Thank you to [narthur157](https://github.com/narthur157) for his amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4), which this Dockerfile is based on.


### PR DESCRIPTION
**What this PR does / why we need it**:
There is currently the problem with the proposed dockerfile that the game cannot write the GSDK Logs. This PR offers a solution by making the folder owned by the ue user.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation