### PR TITLE
Updated README.md in Unreal plugin for game server port number setting in MPS server.

### DIFF
--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -221,19 +221,35 @@ a dedicated server, so you could wrap the call to ReadyForPlayers() as such at t
     FGameServerConnectionInfo ConnectionInfo = UGSDKUtils::GetGameServerConnectionInfo();
 
     for (auto& GamePorts : ConnectionInfo.GamePortsConfiguration) {
-        if (GamePorts.Name == TEXT("<Your game server port name on MPS dashboard>")) {
+        if (GamePorts.Name == TEXT("<portname>")) {
             UE_LOG(LogTemp, Log, TEXT("GSDK Game port name: %s"), *GamePorts.Name);
-            UE_LOG(LogTemp, Log, TEXT("GSDK Game server listerning port: %d"), GamePorts.ServerListeningPort);
+            UE_LOG(LogTemp, Log, TEXT("GSDK Game server listening port: %d"), GamePorts.ServerListeningPort);
             UE_LOG(LogTemp, Log, TEXT("GSDK Game client connection port: %d"), GamePorts.ClientConnectionPort);
             FURL::UrlConfig.DefaultPort = GamePorts.ServerListeningPort;
             break;
         }
     }
 ```
-Add above codes after the code below
+Add above lines after the line below
 ```cpp
 UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck)
 ````
+Update <portname> with the name you entered in the port name when creating a build on the MPS dashboard.
+When you use LocalMultiplayerAgent, match <portname> with value of "PortMappingsList.GamePort.Name" in MultiplayerSettings.json file.
+```json
+  "PortMappingsList": [
+    [
+      {
+        "NodePort": 7777,
+        "GamePort": {
+          "Name": "<portname>",
+          "Number": 80,
+          "Protocol": "UTP"
+        }
+      }
+    ]
+  ],
+```
 ----
 
 Lastly, add these method implementations to the bottom of [YourGameInstanceClassName].cpp file:

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -216,6 +216,25 @@ a dedicated server, so you could wrap the call to ReadyForPlayers() as such at t
 #endif
 ```
 ----
+##### Set the game server port number with MPS's configuration.
+```cpp
+    FGameServerConnectionInfo ConnectionInfo = UGSDKUtils::GetGameServerConnectionInfo();
+
+    for (auto& GamePorts : ConnectionInfo.GamePortsConfiguration) {
+        if (GamePorts.Name == TEXT("<Your game server port name on MPS dashboard>")) {
+            UE_LOG(LogTemp, Log, TEXT("GSDK Game port name: %s"), *GamePorts.Name);
+            UE_LOG(LogTemp, Log, TEXT("GSDK Game server listerning port: %d"), GamePorts.ServerListeningPort);
+            UE_LOG(LogTemp, Log, TEXT("GSDK Game client connection port: %d"), GamePorts.ClientConnectionPort);
+            FURL::UrlConfig.DefaultPort = GamePorts.ServerListeningPort;
+            break;
+        }
+    }
+```
+Add above codes after the code below
+```cpp
+UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck)
+````
+----
 
 Lastly, add these method implementations to the bottom of [YourGameInstanceClassName].cpp file:
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing section on Readme.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:
This PR is to explain how the game server sets the port number when opening the port number in Unreal.
In the MPS server, the game server must open the port with a specific number assigned by the MPS.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility