### PR TITLE
README overhaul: More complete, and organize as separate pages

### DIFF
--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -17,7 +17,8 @@ The sample game these instructions were created with was called ThirdPersonMP, s
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
 * Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
-* [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
+* [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)
+	* [Optional] Alternately, download the [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
 * [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/en-US/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
 
 ## Project creation

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -1,4 +1,5 @@
 # Instructions on Integrating the PlayFab GSDK Unreal Plugin Preview
+
 This Unreal Plugin is implementing the GSDK directly in Unreal Engine.
 
 This plugin offers both a Blueprint API and a C++ API. This does however not mean that the Blueprint API does not require the game to be a C++ project. If it is currently a Blueprint only project, then you need to convert it beforehand, before adding the plugin.
@@ -11,6 +12,7 @@ It was tested with Unreal Engine 4.26.2, but should work with other engines as w
 The sample game these instructions were created with was called ThirdPersonMP, so replace anywhere you see that with your game name.
 
 # Prerequisites:
+
 - Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 - Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
 - [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
@@ -20,6 +22,7 @@ The sample game these instructions were created with was called ThirdPersonMP, s
 # Setup
 
 ## Adding the plugin to the project
+
 When using the plugin a few things need to be taken care off.
 
 First, open File Explorer and create a folder called “Plugins” in your games' root directory and in the Plugins folder, create a folder called "PlayFabGSDK". Then, drag all the files from the UnrealPlugin folder in this repo into the Plugins/PlayFabGSDK folder.
@@ -54,6 +57,7 @@ See the example below:
 ```
 
 ## Include the plugin in your modules
+
 Update <modulename>.Build.cs file to add "PlayFabGSDK" into the PublicDependencyModuleNames.AddRange(); list as follows:
 
 ```csharp
@@ -127,6 +131,7 @@ Then close Unreal and generate project files in source build mode again.
 Then using Visual Studio, open those newly created files and follow instructions to modify the Game Instance class.
 
 ### Modify the Game Instance Class
+
 Locate your GameInstance class, which is most likely called something similar to [your game name]GameInstance or MyGameInstance. From now on, your game instance class will
 be denoted with [YourGameInstanceClassName].
 
@@ -177,6 +182,7 @@ Make sure that the following are included:
 Then locate your Init() function. If you _**don't**_ have an Init() function yet, then add in the function as such:
 
 ##### Creating Init() function
+
 ```cpp 
 void U[YourGameInstanceClassName]::Init()
 {
@@ -195,6 +201,7 @@ go to check in [YourGameInstanceClassName].cpp file to see if you have a variabl
 for a dedicated server. **If you can find this variable**, then add in this in at the end of your Init() function:
 
 ##### Modifying Existing Init() function
+
 ```cpp
 	if (IsDedicatedServerInstance() == true)
 	{
@@ -248,6 +255,7 @@ bool UMyGameInstance::OnGSDKHealthCheck()
 ```
 
 ## Blueprint implementation
+
 In a folder of your choice in the Content Browser right-click and create a Blueprint class. In the All classes dropdown menu find the GameInstance class. In this example the blueprint is named "BP_GameInstance".
 
 Double-click the blueprint and on the left side hover over the function field and click the Override dropdown. Select the Init function.
@@ -274,10 +282,12 @@ In the end add the "Ready for Players" to be able to react to the ready signal o
 After creating a custom game instance class that integrates with the gsdk, you have to configure your project to actually use this newly created game instance class. There are two ways to do this - either through the Unreal Engine editor or by editing DefaultEngine.ini directly.
 
 ###### In the Unreal Editor
+
 In the editor, this can also be set through the UI in the editor. In the editor go to Edit -> Project Settings. From that opened window,
 navigate to Maps&Modes on the left side. Scroll to the bottom, and then you can set the option "Game Instance Class" to your new game instance class directly, and avoid typos.
 
 ###### In DefaultEngine.ini
+
 Or you can update DefaultEngine.ini file and add this:
 ```ini
 [/Script/EngineSettings.GameMapsSettings]
@@ -285,12 +295,15 @@ GameInstanceClass=/Script/[game name].MyGameInstance
 ```
 
 ## Include Pre-requisites for Windows Dedicated Server
+
 There are two ways to include the app-local prerequisites - either through the Unreal Engine editor or by editing DefaultGame.ini.
 
 ### In the Unreal Editor
+
 In the editor go to Edit -> Project Settings. In the opened window navigate to Packaging on the left side. Scroll to the bottom of the list, and tick "Include app-local prerequisites".
 
 ### In DefaultGame.ini
+
 Or you can update DefaultGame.ini to show the following:
 ```ini
 [/Script/UnrealEd.ProjectPackagingSettings]
@@ -314,6 +327,7 @@ You can now use this packaged version of your game server to [test with LocalMul
 or to use it directly with PlayFab by [creating a build](https://developer.playfab.com/) and then using [PlayFab MpsAllocatorSample](https://github.com/PlayFab/MpsSamples/blob/master/MpsAllocatorSample/README.md).
 
 ## Setting up a Windows Dedicated Server on PlayFab
+
 An important note about this is that you need to set the start command in process-based mode to \<root folder\>\\Binaries\\Win64\\\<project name\>Server.exe (or however the executable is called in the folder).
 
 In container-based mode use \<mount folder\>\\\<root folder\>\\Binaries\\Win64\\\<project name\>Server.exe (or however the executable is called in the folder).
@@ -321,9 +335,11 @@ In container-based mode use \<mount folder\>\\\<root folder\>\\Binaries\\Win64\\
 **If you use the executable in the root folder, the server will fail to initialize with the PlayFab system.**
 
 ## Setting up a Linux Dedicated Server on PlayFab
+
 During testing the following Dockerfile + startup.sh script worked excellent with the PlayFab Linux VM:
 
 ### The Dockerfile:
+
 ```Dockerfile
 FROM ubuntu:18.04
 
@@ -342,6 +358,7 @@ CMD ./startup.sh
 ```
 
 ### startup&#46;sh bash script:
+
 ```bash
 chown -R ue.ue $PF_SERVER_LOG_DIRECTORY
 su ue -c ./<projectname>Server.sh

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -1,8 +1,8 @@
 # Instructions on Integrating the PlayFab GSDK Unreal Plugin Preview
 
-This Unreal Plugin is implementing the GSDK directly in Unreal Engine.
+This article describes how to integrate PlayFab Multiplayer Server SDK (GSDK) Unreal Online Subsystem (OSS) plugin with your Unreal game project.
 
-This plugin offers both a Blueprint API and a C++ API. This does however not mean that the Blueprint API does not require the game to be a C++ project. If it is currently a Blueprint only project, then you need to convert it beforehand, before adding the plugin.
+This plugin offers both a Blueprint API and a C++ API. The Blueprint API still requires your Unreal Project to be a C++ project, and will not work on a Blueprint only project. If it is currently a Blueprint only project, then you need to convert to a C++ project beforehand, before adding the plugin.
 
 The following nodes are supported:
 ![PlayFab GSDK Blueprint Nodes](Documentation/GSDKBlueprintNodes.png)

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -44,4 +44,4 @@ Finally, you're ready to [deploy your game-server to PlayFab](ThirdPersonMPCloud
 
 Thank you to [Nick Arthur](https://github.com/narthur157) for his amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4).
 
-Thank you to [Adam Rehn]{https://github.com/adamrehn) for all his work with Unreal and Docker, including code, samples, examples, and tutorials.
+Thank you to [Adam Rehn](https://github.com/adamrehn) for all his work with Unreal and Docker, including code, samples, examples, and tutorials.

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -15,11 +15,11 @@ The sample game these instructions were created with was called ThirdPersonMP, s
 
 * Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
 * [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)
 	* [Optional] Alternately, download the [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
-* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/en-US/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
+* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
 
 ## Project creation
 

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -13,21 +13,36 @@ The sample game these instructions were created with was called ThirdPersonMP, s
 
 ## Requirements
 
-* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
-* Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
+* Download Visual Studio. The [community version](https://visualstudio.microsoft.com/vs/community/) is free.
+	* Required workloads: .NET desktop development and Desktop development with C++
+* Download Unreal Engine Source Code. This plugin was tested on Unreal Engine 4.26.2. For instructions, see [Downloading Unreal Engine Source code (external)](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/).
+* Download [Unreal PlayFabGSDK Plugin](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin).
 * [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)
-	* [Optional] Alternately, download the [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
-* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
+	* [Optional] Alternatively, download [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent).
+* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab). This plugin is not required for GSDK but is required for many PlayFab services, including login.
 
 ## Project creation
 
-Unreal GSDK is installed into an Unreal server project. You will need a network-enabled multiplayer Unreal project with a dedicated-server mode. If you do not have one, you can follow our [Unreal prerequsitie setup](ThirdPersonMPSetup.md) guide. Once you have a network-enabled, multiplayer game, with a dedicated server, return here and continue.
+The Unreal server project needs to be a network-enabled multiplayer Unreal project with a dedicated-server mode. If you don't have a project that meets these prerequisites, follow our [Unreal prerequisite set up guide](ThirdPersonMPSetup.md) to set one up. Once you have a network-enabled, multiplayer game, with a dedicated server, return to this step and continue.
+
+When ready, open your network-enabled multiplayer Unreal server project, and continue to the next step to install the Unreal GSDK.
 
 ## Project GSDK setup
 
-With a multiplayer project configured for both a network connected game-client and game-server, you're ready to [install the GSDK](ThirdPersonMPGSDKSetup.md). This will allow your server to run on PlayFab Multiplayer Services.
+* GSDK Project Prerequisite details
+	* Dedicated Server:
+		* Your project should have a separate {ProjectName}Server.Target.cs file
+		* This file should contain ```Type = TargetType.Server;``` to enable dedicated server mode
+		* When built in "development server" configuration for Win64, your output contains {ProjectName}Server.exe
+	* Network-enabled:
+		* There are multiple ways to meet this requirement, but the simple answer is: your client can establish a network connection with a game server on a separate machine, and communicate meaningfully
+		* Our instructions direct you to do this through Unreal's built-in data replication system which handles most of this for you
+		* A more direct way to do this is with direct socket use, such as through the ISocketSubsystem, which is a much more advanced topic
+	* Multiplayer:
+		* Your game server can accept multiple incoming client connections, and communicate properly with both
+		* Again, with Unreal's built-in data replication, this is mostly handled for you
+
+With a properly configure multiplayer project, you're ready to [install the GSDK](ThirdPersonMPGSDKSetup.md). This will allow your server to run on PlayFab Multiplayer Services.
 
 ## Unreal Project Build Configurations
 
@@ -39,7 +54,7 @@ Once you have any client build, and a "Development Server" build, you can [test 
 
 ## Deploy to PlayFab
 
-Finally, you're ready to [deploy your game-server to PlayFab](ThirdPersonMPCloudDeploy.md), and test with real game servers in the cloud.
+Finally, you're ready to [create game servers in the cloud](ThirdPersonMPCloudDeploy.md) using PlayFab Multiplayer Services.
 
 # Acknowledgements
 

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -11,89 +11,37 @@ It was tested with Unreal Engine 4.26.2, but should work with other engines as w
 
 The sample game these instructions were created with was called ThirdPersonMP, so replace anywhere you see that with your game name.
 
-# Prerequisites:
+## Requirements
 
-- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
-- Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
-- [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
+* [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
+* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/en-US/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
 
-# Project creation
+## Project creation
 
 Unreal GSDK is installed into an Unreal server project. You will need a network-enabled multiplayer Unreal project with a dedicated-server mode. If you do not have one, you can follow our [Unreal prerequsitie setup](ThirdPersonMPSetup.md) guide. Once you have a network-enabled, multiplayer game, with a dedicated server, return here and continue.
 
-# Project GSDK setup
+## Project GSDK setup
 
 With a multiplayer project configured for both a network connected game-client and game-server, you're ready to [install the GSDK](ThirdPersonMPGSDKSetup.md). This will allow your server to run on PlayFab Multiplayer Services.
 
-# Unreal Project Build Configurations
+## Unreal Project Build Configurations
 
 Once the GSDK is installed and configured in your project, you can [build your Unreal project](ThirdPersonMPBuild.md). There are multiple build configurations you will need to execute the full range of tests in future steps.
 
-# Test Local Server Deployment
+## Test Local Server Deployment
 
 Once you have any client build, and a "Development Server" build, you can [test the MPS deployment process locally](ThirdPersonMPLocalDeploy.md), and verify your server works.
 
-# Deploy to PlayFab
+## Deploy to PlayFab
 
-Finally, you're ready to deploy your game-server to PlayFab, and test with real game servers in the cloud. _TODO-LINK!_
+Finally, you're ready to [deploy your game-server to PlayFab](ThirdPersonMPCloudDeploy.md), and test with real game servers in the cloud.
 
+# Acknowledgements
 
+Thank you to [Nick Arthur](https://github.com/narthur157) for his amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4).
 
-
-
-TODO: MOVE THIS TO PLAYFAB-DEPLOY FILE
-
-## Packaging the game server
-
-Make sure that you have just built your project in development editor in Visual Studio *before* doing this next step, because sometimes building fails when opening the project directly through the .uproject file.
-
-Right click on the .uproject file in your file editor and select "Generate Visual Studio Project Files". 
-
-Then open the .uproject file.
-
-In the top left of the Unreal editor menu, click on File -> Package -> Target Configuration -> [game name]Server and then go to File -> Package -> Windowsx64. 
-You can now use this packaged version of your game server to [test with LocalMultiplayerAgent](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/servers/locally-debugging-game-servers-and-integration-with-playfab) 
-or to use it directly with PlayFab by [creating a build](https://developer.playfab.com/) and then using [PlayFab MpsAllocatorSample](https://github.com/PlayFab/MpsSamples/blob/master/MpsAllocatorSample/README.md).
-
-## Setting up a Windows Dedicated Server on PlayFab
-
-An important note about this is that you need to set the start command in process-based mode to \<root folder\>\\Binaries\\Win64\\\<project name\>Server.exe (or however the executable is called in the folder).
-
-In container-based mode use \<mount folder\>\\\<root folder\>\\Binaries\\Win64\\\<project name\>Server.exe (or however the executable is called in the folder).
-
-**If you use the executable in the root folder, the server will fail to initialize with the PlayFab system.**
-
-## Setting up a Linux Dedicated Server on PlayFab
-
-During testing the following Dockerfile + startup.sh script worked excellent with the PlayFab Linux VM:
-
-### The Dockerfile:
-
-```Dockerfile
-FROM ubuntu:18.04
-
-# Unreal refuses to run as root user, so we must create a user to run as
-# Docker uses root by default
-RUN useradd --system ue
-USER ue
-
-EXPOSE 7777/udp
-
-WORKDIR /server
-
-COPY --chown=ue:ue . /server
-USER root
-CMD ./startup.sh
-```
-
-### startup&#46;sh bash script:
-
-```bash
-chown -R ue.ue $PF_SERVER_LOG_DIRECTORY
-su ue -c ./<projectname>Server.sh
-```
-Make sure that the line endings in the startup&#46;sh file are LF (\\n) and not CRLF (\\r\\n).
-
-Thank you to [narthur157](https://github.com/narthur157) for his amazing [Dockerfile](https://github.com/narthur157/playfab-gsdk-ue4), which this Dockerfile is based on.
+Thank you to [Adam Rehn]{https://github.com/adamrehn) for all his work with Unreal and Docker, including code, samples, examples, and tutorials.

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -11,9 +11,11 @@ It was tested with Unreal Engine 4.26.2, but should work with other engines as w
 The sample game these instructions were created with was called ThirdPersonMP, so replace anywhere you see that with your game name.
 
 # Prerequisites:
-- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website (this was tested on 4.26.2)
+- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 - Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
+- [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
 - Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	- Requires Workloads: .NET desktop development, and Desktop development with C++
 
 # Setup
 
@@ -72,19 +74,16 @@ Then, build the project in Visual Studio and start the Editor by selecting the D
 
 ![image depicting Visual Studio with the option to build in Development Editor Mode](Documentation/DevelopmentEditor.png)
 
-## Disabling Plugins
-When you add Dedicated Server support to your project, you will definitely have created a <projectname>Server.Target.cs file.
+## Project Setup
 
-Update [game name]Server.target.cs and add the following lines to the constructor of this class:
+Unreal GSDK is installed into the server project. You will need a server-enabled project. If you do not have one, you can follow these examples. Once finished, return here and continue.
 
-```csharp 
-DisablePlugins.Add("WMFMediaPlayer");
-DisablePlugins.Add("AsyncLoadingScreen"); //if you are using this plugin
-DisablePlugins.Add("WindowsMoviePlayer");
-DisablePlugins.Add("MediaFoundationMediaPlayer");
-```
+* https://docs.unrealengine.com/4.27/en-US/Resources/Templates/ThirdPerson/
+* https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/
 
-Result should be:
+Once your project has enabled server mode, you will have a <projectname>Server.Target.cs file.
+
+Result should similar to:
 ```csharp 
 public class <projectname>ServerTarget : TargetRules
 {
@@ -93,14 +92,20 @@ public class <projectname>ServerTarget : TargetRules
         Type = TargetType.Server;
         DefaultBuildSettings = BuildSettingsVersion.V2;
         ExtraModuleNames.AddRange( new string[] { "<projectname>" } );
-        
-        DisablePlugins.Add("WMFMediaPlayer");
-        DisablePlugins.Add("AsyncLoadingScreen"); //if you are using this plugin
-        DisablePlugins.Add("WindowsMoviePlayer");
-        DisablePlugins.Add("MediaFoundationMediaPlayer");
+
+	// You may have additional configuration based on your server needs
     }
 }
 ```
+
+For Windows builds, you may need to add these optional configuations:
+```csharp
+DisablePlugins.Add("WMFMediaPlayer");
+DisablePlugins.Add("AsyncLoadingScreen"); //if you are using this plugin
+DisablePlugins.Add("WindowsMoviePlayer");
+DisablePlugins.Add("MediaFoundationMediaPlayer");
+```
+However, these configurations are invalid for a Linux server build.
 
 ## Example C++ integration
 

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -27,9 +27,13 @@ Unreal GSDK is installed into an Unreal server project. You will need a network-
 
 With a multiplayer project configured for both a network connected game-client and game-server, you're ready to [install the GSDK](ThirdPersonMPGSDKSetup.md). This will allow your server to run on PlayFab Multiplayer Services.
 
-# Test Local Deployment
+# Unreal Project Build Configurations
 
-Once the GSDK is installed and configured in your project, you can [test the MPS deployment process locally](ThirdPersonMPLocalDeploy.md), and verify your server works.
+Once the GSDK is installed and configured in your project, you can [build your Unreal project](ThirdPersonMPBuild.md). There are multiple build configurations you will need to execute the full range of tests in future steps.
+
+# Test Local Server Deployment
+
+Once you have any client build, and a "Development Server" build, you can [test the MPS deployment process locally](ThirdPersonMPLocalDeploy.md), and verify your server works.
 
 # Deploy to PlayFab
 
@@ -39,8 +43,7 @@ Finally, you're ready to deploy your game-server to PlayFab, and test with real 
 
 
 
-
-TODO: MOVE THIS TO DEPLOY FILE
+TODO: MOVE THIS TO PLAYFAB-DEPLOY FILE
 
 ## Packaging the game server
 

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -80,10 +80,7 @@ Then, build the project in Visual Studio and start the Editor by selecting the D
 
 ## Project Setup
 
-Unreal GSDK is installed into the server project. You will need a server-enabled project. If you do not have one, you can follow these examples. Once finished, return here and continue.
-
-* https://docs.unrealengine.com/4.27/en-US/Resources/Templates/ThirdPerson/
-* https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/
+Unreal GSDK is installed into the server project. You will need a network-enabled multiplayer Unreal project with a dedicated-server mode. If you do not have one, you can follow our [Unreal prerequsitie setup](ThirdPersonMPSetup.md) guide. Once you have a network-enabled, multiplayer game, with a dedicated server, return here and continue.
 
 Once your project has enabled server mode, you will have a <projectname>Server.Target.cs file.
 
@@ -109,7 +106,7 @@ DisablePlugins.Add("AsyncLoadingScreen"); //if you are using this plugin
 DisablePlugins.Add("WindowsMoviePlayer");
 DisablePlugins.Add("MediaFoundationMediaPlayer");
 ```
-However, these configurations are invalid for a Linux server build.
+NOTE: These configurations are invalid for a Linux server build.
 
 ## Example C++ integration
 

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -13,301 +13,34 @@ The sample game these instructions were created with was called ThirdPersonMP, s
 
 # Prerequisites:
 
+- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	- Requires Workloads: .NET desktop development, and Desktop development with C++
 - Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 - Download the [Unreal PlayFabGSDK Plugin folder](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
 - [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
-- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	- Requires Workloads: .NET desktop development, and Desktop development with C++
 
-# Setup
+# Project creation
 
-## Adding the plugin to the project
+Unreal GSDK is installed into an Unreal server project. You will need a network-enabled multiplayer Unreal project with a dedicated-server mode. If you do not have one, you can follow our [Unreal prerequsitie setup](ThirdPersonMPSetup.md) guide. Once you have a network-enabled, multiplayer game, with a dedicated server, return here and continue.
 
-When using the plugin a few things need to be taken care off.
+# Project GSDK setup
 
-First, open File Explorer and create a folder called “Plugins” in your games' root directory and in the Plugins folder, create a folder called "PlayFabGSDK". Then, drag all the files from the UnrealPlugin folder in this repo into the Plugins/PlayFabGSDK folder.
+With a multiplayer project configured for both a network connected game-client and game-server, you're ready to [install the GSDK](ThirdPersonMPGSDKSetup.md). This will allow your server to run on PlayFab Multiplayer Services.
 
-Open the .uproject file in a text editor of your choice. In the plugins array add the PlayFabGSDK.
+# Test Local Deployment
 
-See the example below:
+Once the GSDK is installed and configured in your project, you can [test the MPS deployment process locally](ThirdPersonMPLocalDeploy.md), and verify your server works.
 
-```json
-{
-    "FileVersion": 3,
-    "EngineAssociation": "4.26",
-    "Category": "",
-    "Description": "",
-    "Modules": [
-        {
-            "Name": "<projectname>",
-            "Type": "Runtime",
-            "LoadingPhase": "Default",
-            "AdditionalDependencies": [
-                "Engine"
-            ]
-        }
-    ],
-    "Plugins": [                    // Add this if it doesn't exist
-        {                           // Add this
-            "Name": "PlayFabGSDK",  // Add this
-            "Enabled": true         // Add this
-        }                           // Add this
-    ]                               // Add this if it doesn't exist
-}
-```
+# Deploy to PlayFab
 
-## Include the plugin in your modules
+Finally, you're ready to deploy your game-server to PlayFab, and test with real game servers in the cloud. _TODO-LINK!_
 
-Update <modulename>.Build.cs file to add "PlayFabGSDK" into the PublicDependencyModuleNames.AddRange(); list as follows:
 
-```csharp
-PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "PlayFabGSDK" });
-```
 
-Right click on the .uproject file and choose the option to "Switch Unreal Engine version", which is how you can quickly check which Unreal Engine version you are currently using. 
-The popup seen below should appear. If you already see that the Unreal Engine version is source build, you don’t need to change anything, so click Cancel. If the Unreal version is not 
-currently the source build, select it from the dropdown list and then click OK. 
 
-![image depicting a window that says "Select Unreal Engine Version"](Documentation/SelectUnrealEngineVersion.png)
 
-Right click on the .uproject file again and select “Generate Visual Studio Project Files".
 
-Then, build the project in Visual Studio and start the Editor by selecting the Development Editor configuration.
-
-![image depicting Visual Studio with the option to build in Development Editor Mode](Documentation/DevelopmentEditor.png)
-
-## Project Setup
-
-Unreal GSDK is installed into the server project. You will need a network-enabled multiplayer Unreal project with a dedicated-server mode. If you do not have one, you can follow our [Unreal prerequsitie setup](ThirdPersonMPSetup.md) guide. Once you have a network-enabled, multiplayer game, with a dedicated server, return here and continue.
-
-Once your project has enabled server mode, you will have a <projectname>Server.Target.cs file.
-
-Result should similar to:
-```csharp 
-public class <projectname>ServerTarget : TargetRules
-{
-    public <projectname>ServerTarget( TargetInfo Target) : base(Target)
-    {
-        Type = TargetType.Server;
-        DefaultBuildSettings = BuildSettingsVersion.V2;
-        ExtraModuleNames.AddRange( new string[] { "<projectname>" } );
-
-	// You may have additional configuration based on your server needs
-    }
-}
-```
-
-For Windows builds, you may need to add these optional configuations:
-```csharp
-DisablePlugins.Add("WMFMediaPlayer");
-DisablePlugins.Add("AsyncLoadingScreen"); //if you are using this plugin
-DisablePlugins.Add("WindowsMoviePlayer");
-DisablePlugins.Add("MediaFoundationMediaPlayer");
-```
-NOTE: These configurations are invalid for a Linux server build.
-
-## Example C++ integration
-
-## Updating the GameInstance Class
-
-### Creating a GameInstance Class
-
-If you are in the process of creating a game from scratch and do not yet have a GameInstance class, then first follow these example instructions to create a GameInstance class. 
-
-If you are using a game that already has a GameInstance class, (for example, ShooterGame from Unreal's sample library), then move on to the section titled _**Modify the GameInstance Class**_.
-
-----
-
-In the Unreal Editor, go to Files->Create a new C++ class and select the option to "Show all classes". Then search for GameInstance. 
-By selecting it directly, everything should be generated correctly and then you can add the functions we detail below.
-
-Then close Unreal and generate project files in source build mode again.
-
-Then using Visual Studio, open those newly created files and follow instructions to modify the Game Instance class.
-
-### Modify the Game Instance Class
-
-Locate your GameInstance class, which is most likely called something similar to [your game name]GameInstance or MyGameInstance. From now on, your game instance class will
-be denoted with [YourGameInstanceClassName].
-
-#### Modifying the GameInstance header file
-
-First, check the include statements and ensure that the following are included in the header file for your GameInstance class ([YourGameInstanceClassName].h):
-
-```cpp
-#include "CoreMinimal.h"
-#include "Engine/GameInstance.h"
-#include "MyGameInstance.generated.h"
-```
-
-Then, add the following declarations to the public section:
-(If you already have an Init() function, there is no need to include another declaration)
-
-```cpp
-public:
-
-    virtual void Init() override;
-    virtual void OnStart() override;
-```
-
-Then, add the following declarations to the protected section of methods:
-```cpp
-protected:
-
-    UFUNCTION()
-    void OnGSDKShutdown();
-    
-    UFUNCTION()
-    bool OnGSDKHealthCheck();
-};
-```
-
-#### Modifying the GameInstance Cpp file
-
-Then, locate the [YourGameInstanceClassName].cpp file. 
-
-Make sure that the following are included:
-
-```cpp 
-#include "[YourGameInstanceClassName].h"
-#include "PlayfabGSDK.h"
-#include "GSDKUtils.h"
-```
-
-Then locate your Init() function. If you _**don't**_ have an Init() function yet, then add in the function as such:
-
-##### Creating Init() function
-
-```cpp 
-void U[YourGameInstanceClassName]::Init()
-{
-    FOnGSDKShutdown_Dyn OnGsdkShutdown;
-    OnGsdkShutdown.BindDynamic(this, &UMyGameInstance::OnGSDKShutdown);
-    FOnGSDKHealthCheck_Dyn OnGsdkHealthCheck;
-    OnGsdkHealthCheck.BindDynamic(this, &UMyGameInstance::OnGSDKHealthCheck);
-
-    UGSDKUtils::RegisterGSDKShutdownDelegate(OnGsdkShutdown);
-    UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck);
-}
-``` 
-----
-If you already **had** an Init() function,
-go to check in [YourGameInstanceClassName].cpp file to see if you have a variable that indicates whether the instance is 
-for a dedicated server. **If you can find this variable**, then add in this in at the end of your Init() function:
-
-##### Modifying Existing Init() function
-
-```cpp
-	if (IsDedicatedServerInstance() == true)
-	{
-		FOnGSDKShutdown_Dyn OnGsdkShutdown;
-		OnGsdkShutdown.BindDynamic(this, &UShooterGameInstance::OnGSDKShutdown);
-		FOnGSDKHealthCheck_Dyn OnGsdkHealthCheck;
-		OnGsdkHealthCheck.BindDynamic(this, &UShooterGameInstance::OnGSDKHealthCheck);
-
-		UGSDKUtils::RegisterGSDKShutdownDelegate(OnGsdkShutdown);
-		UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck);
-
-		OnStart();
-	}
-```
-**If you can't find a variable like IsDedicatedServerInstance(),** we still want to make sure that ReadyForPlayers() and onStart() are used when using 
-a dedicated server, so you could wrap the call to ReadyForPlayers() as such at the bottom of the Init function:
-
-```cpp
-#if UE_SERVER
-    if (!UGSDKUtils::ReadyForPlayers())
-    {
-        FPlatformMisc::RequestExit(false);
-    }
-#endif
-```
-----
-
-Lastly, add these method implementations to the bottom of [YourGameInstanceClassName].cpp file:
-
-```cpp
-void UMyGameInstance::OnStart()
-{
-    UE_LOG(LogTemp, Warning, TEXT("Reached onStart!"));
-    if (!UGSDKUtils::ReadyForPlayers())
-    {
-        FPlatformMisc::RequestExit(false);
-    }
-}
-
-void UMyGameInstance::OnGSDKShutdown()
-{
-    UE_LOG(LogTemp, Warning, TEXT("Shutdown!"));
-    FPlatformMisc::RequestExit(false);
-}
-
-bool UMyGameInstance::OnGSDKHealthCheck()
-{
-    UE_LOG(LogTemp, Warning, TEXT("Healthy!"));
-    return true;
-}
-```
-
-## Blueprint implementation
-
-In a folder of your choice in the Content Browser right-click and create a Blueprint class. In the All classes dropdown menu find the GameInstance class. In this example the blueprint is named "BP_GameInstance".
-
-Double-click the blueprint and on the left side hover over the function field and click the Override dropdown. Select the Init function.
-
-Right-click in the graph and add in all register GSDK function. 
-
-For GSDK Shutdown and Maintenance Delegate drag out the a line from the red square, and select "Add Custom Event". 
-
-For "Register GSDK Health Check Delegate" select the "Create Event" in the "Event Dispatchers".
-![PlayFab GSDK Health Check select function](Documentation/BlueprintAddRegisterHealthCheckDelegate.png)
-In the dropdown of the new node "Create matching function". **This is important, as the GSDK Health Check Delegate has a return value.**
-![PlayFab GSDK Health Check select function](Documentation/BlueprintRegisterHealthCheckDelegate.png)
-
-In the function make sure the return boolean value is checked.
-![PlayFab GSDK Health Check function](Documentation/BlueprintGSDKHealthCheckFunction.png)
-
-Don't forget to connect all the nodes to the Event Init node.
-
-In the end add the "Ready for Players" to be able to react to the ready signal of PlayFab.
-![PlayFab GSDK Full Graph](Documentation/BlueprintFullGraph.png)
-
-## Set the Game Instance class
-    
-After creating a custom game instance class that integrates with the gsdk, you have to configure your project to actually use this newly created game instance class. There are two ways to do this - either through the Unreal Engine editor or by editing DefaultEngine.ini directly.
-
-###### In the Unreal Editor
-
-In the editor, this can also be set through the UI in the editor. In the editor go to Edit -> Project Settings. From that opened window,
-navigate to Maps&Modes on the left side. Scroll to the bottom, and then you can set the option "Game Instance Class" to your new game instance class directly, and avoid typos.
-
-###### In DefaultEngine.ini
-
-Or you can update DefaultEngine.ini file and add this:
-```ini
-[/Script/EngineSettings.GameMapsSettings]
-GameInstanceClass=/Script/[game name].MyGameInstance
-```
-
-## Include Pre-requisites for Windows Dedicated Server
-
-There are two ways to include the app-local prerequisites - either through the Unreal Engine editor or by editing DefaultGame.ini.
-
-### In the Unreal Editor
-
-In the editor go to Edit -> Project Settings. In the opened window navigate to Packaging on the left side. Scroll to the bottom of the list, and tick "Include app-local prerequisites".
-
-### In DefaultGame.ini
-
-Or you can update DefaultGame.ini to show the following:
-```ini
-[/Script/UnrealEd.ProjectPackagingSettings]
-IncludeAppLocalPrerequisites=True
-```
-
-If the category already exists in your DefaultGame.ini, then just add the second line to it. This ensures that all app local dependencies ship with the game as well.
-
-If you are using Continuous Integration (CI), then you could add it to your setup to only turn this flag on when building a dedicated server, so the additional dlls only get added if it is a dedicated server build.
+TODO: MOVE THIS TO DEPLOY FILE
 
 ## Packaging the game server
 

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -16,7 +16,9 @@ The sample game these instructions were created with was called ThirdPersonMP, s
 * Download Visual Studio. The [community version](https://visualstudio.microsoft.com/vs/community/) is free.
 	* Required workloads: .NET desktop development and Desktop development with C++
 * Download Unreal Engine Source Code. This plugin was tested on Unreal Engine 4.26.2. For instructions, see [Downloading Unreal Engine Source code (external)](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/).
-* Download [Unreal PlayFabGSDK Plugin](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin).
+* If you haven't already, please git clone this repo to your local machinne
+	* ```git clone https://github.com/PlayFab/gsdk.git```
+	* Later steps will involve integrating files from this repo to your project
 * [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)
 	* [Optional] Alternatively, download [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent).
 * [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab). This plugin is not required for GSDK but is required for many PlayFab services, including login.

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -61,9 +61,7 @@ See the example below:
 Update <modulename>.Build.cs file to add "PlayFabGSDK" into the PublicDependencyModuleNames.AddRange(); list as follows:
 
 ```csharp
-PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "PlayFabGSDK"});
-
-PrivateDependencyModuleNames.AddRange(new string[] { });
+PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "PlayFabGSDK" });
 ```
 
 Right click on the .uproject file and choose the option to "Switch Unreal Engine version", which is how you can quickly check which Unreal Engine version you are currently using. 

--- a/UnrealPlugin/README.md
+++ b/UnrealPlugin/README.md
@@ -1,4 +1,4 @@
-# Instructions on Integrating the PlayFab GSDK Unreal Plugin Preview
+# How to use PlayFab GSDK Unreal plugin
 
 This article describes how to integrate PlayFab Multiplayer Server SDK (GSDK) Unreal Online Subsystem (OSS) plugin with your Unreal game project.
 

--- a/UnrealPlugin/ThirdPersonMPBuild.md
+++ b/UnrealPlugin/ThirdPersonMPBuild.md
@@ -13,13 +13,13 @@ The purpose of this guide is to describe all the build configurations needed to 
 
 * Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
-* Knowledge about [Unreal Build Configuration](https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/CompilingProjects/) options
+* Knowledge about [Unreal Build Configuration](https://docs.unrealengine.com/4.27/ProductionPipelines/DevelopmentSetup/CompilingProjects/) options
 
 ## Instructions
 
-The [GSDK setup](ThirdPersonMPGSDKSetup.md) guide previously described the steps to "Switch Unreal Engine Version" and "Generate Visual Studio project files". There is also an [Unreal guide](https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/CompilingProjects/) about the various compilation options, which you should review.
+The [GSDK setup](ThirdPersonMPGSDKSetup.md) guide previously described the steps to "Switch Unreal Engine Version" and "Generate Visual Studio project files". There is also an [Unreal guide](https://docs.unrealengine.com/4.27/ProductionPipelines/DevelopmentSetup/CompilingProjects/) about the various compilation options, which you should review.
 
 ### Development Editor
 

--- a/UnrealPlugin/ThirdPersonMPBuild.md
+++ b/UnrealPlugin/ThirdPersonMPBuild.md
@@ -1,0 +1,29 @@
+# Building the ThirdPersonMP Example Project
+
+The purpose of this guide is to describe all the build configurations needed to test and verify your Unreal project.
+
+## Goals
+
+* Build the "Development Editor"
+* Build a game client
+* Build the "Development Server"
+* Build a release Server
+
+## Requirements
+
+- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	- Requires Workloads: .NET desktop development, and Desktop development with C++
+- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
+
+
+## Instructions
+
+TODO:
+
+
+## Navigation
+
+You are now ready to [deploy your game server](ThirdPersonMPLocalDeploy.md) to PlayFab MPS and test your project in the cloud.
+
+Alternately, you can return to the main [Unreal GSDK Plugin](README.md#deploy-to-playfab) guide.

--- a/UnrealPlugin/ThirdPersonMPBuild.md
+++ b/UnrealPlugin/ThirdPersonMPBuild.md
@@ -11,16 +11,57 @@ The purpose of this guide is to describe all the build configurations needed to 
 
 ## Requirements
 
-- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
-
+* Knowledge about [Unreal Build Configuration](https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/CompilingProjects/) options
 
 ## Instructions
 
-TODO:
+The [GSDK setup](ThirdPersonMPGSDKSetup.md) guide previously described the steps to "Switch Unreal Engine Version" and "Generate Visual Studio project files". There is also an [Unreal guide](https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/CompilingProjects/) about the various compilation options, which you should review.
 
+### Development Editor
+
+The development editor should be the first thing you build. To do this, find your ThirdPersonMP.uproject file, right click, and "Generate Visual Studio project files" (You may have already done this in the previous guide, in which case, you can skip this step. Once complete, you can open ThirdPersonMP.sln in Visual Studio.
+
+Once Visual Studio loads, change your configuration to "Development Server". The Solution Configuration dropdown is sometimes hard to read, but can be resized in the toolbar customization options. Now, build. The first time you do this, it can take several hours, but you likely did this in the previous guide. Repeated builds should be fairly fast for a small project. Once finished, you can run/debug the project Solution/Games/ThirdPersonMP. This will start the Development Editor.
+
+### Shipping Client
+
+Run the Development Editor, and from the development editor window, pick these options in this order:
+
+* File -> Package Project -> Build Target -> ThirdPersonMP (Or the name of your project)
+* File -> Package Project -> Build Configuration -> Development
+* File -> Package Project -> Windows (64-bit)
+* (This opens a popup window asking you to pick a location - make sure you remember this location)
+* {Wait a very long time}
+	* The first shipping client build will take upto multiple hours, even if you've already built Development Editor
+	* Repeat builds will be much faster for a simple project like ThirdPersonMP
+* Open the client location you picked and find ThirdPersonMP.exe
+
+### Development Server
+
+* Close the Development Editor (Unreal is no longer running, only Visual Studio should be open now)
+* Toolbars -> Configuration -> "Development Server"
+* Build/Rebuild Solution
+* {Wait a very long time}
+	* The first development server build will take upto multiple hours, even if you've already built Development Editor
+	* Repeat builds will be much faster for a simple project like ThirdPersonMP
+* Use Explorer to find {projectLocation}\Binaries\Win64\ThirdPersonMPServer.exe
+
+### Shipping Server
+
+Run the Development Editor, and from the development editor window, pick these options in this order:
+
+* File -> Package Project -> Build Target -> ThirdPersonMPServer (Or the name of your project)+Server
+* File -> Package Project -> Build Configuration -> Development
+* File -> Package Project -> Windows (64-bit)
+* (This opens a popup window asking you to pick a location - make sure you remember this location)
+* {Wait a very long time}
+	* The first shipping server build will take upto multiple hours, even if you've already built Development Editor
+	* Repeat builds will be much faster for a simple project like ThirdPersonMP
+* Open the server location you picked and find ThirdPersonMPServer.exe
 
 ## Navigation
 

--- a/UnrealPlugin/ThirdPersonMPBuild.md
+++ b/UnrealPlugin/ThirdPersonMPBuild.md
@@ -65,6 +65,6 @@ Run the Development Editor, and from the development editor window, pick these o
 
 ## Navigation
 
-You are now ready to [deploy your game server](ThirdPersonMPLocalDeploy.md) to PlayFab MPS and test your project in the cloud.
+You are now ready to [test your game server](ThirdPersonMPLocalDeploy.md) on your local machine.
 
 Alternately, you can return to the main [Unreal GSDK Plugin](README.md#deploy-to-playfab) guide.

--- a/UnrealPlugin/ThirdPersonMPBuild.md
+++ b/UnrealPlugin/ThirdPersonMPBuild.md
@@ -11,9 +11,9 @@ The purpose of this guide is to describe all the build configurations needed to 
 
 ## Requirements
 
-* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Visual Studio. The [community version](https://visualstudio.microsoft.com/vs/community/) is free.
+	* Required workloads: .NET desktop development and Desktop development with C++
+* Download Unreal Engine Source Code. This plugin was tested on Unreal Engine 4.26.2. For instructions, see [Downloading Unreal Engine Source code (external)](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/).
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
 * Knowledge about [Unreal Build Configuration](https://docs.unrealengine.com/4.27/ProductionPipelines/DevelopmentSetup/CompilingProjects/) options
 

--- a/UnrealPlugin/ThirdPersonMPCloudDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPCloudDeploy.md
@@ -11,7 +11,7 @@ The purpose of this guide is the final step, deploying your game to the PlayFab 
 
 * Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
 * [Release Server](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio or Development Editor
 * [Client](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio or Development Editor
@@ -27,7 +27,7 @@ Right click on the .uproject file in your file editor and select "Generate Visua
 Then open the .uproject file.
 
 In the top left of the Unreal editor menu, click on File -> Package -> Target Configuration -> [game name]Server and then go to File -> Package -> Windowsx64. 
-You can now use this packaged version of your game server to [test with LocalMultiplayerAgent](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/servers/locally-debugging-game-servers-and-integration-with-playfab) 
+You can now use this packaged version of your game server to [test with LocalMultiplayerAgent](https://docs.microsoft.com/gaming/playfab/features/multiplayer/servers/locally-debugging-game-servers-and-integration-with-playfab) 
 or to use it directly with PlayFab by [creating a build](https://developer.playfab.com/) and then using [PlayFab MpsAllocatorSample](https://github.com/PlayFab/MpsSamples/blob/master/MpsAllocatorSample/README.md).
 
 ### Setting up a Windows Dedicated Server on PlayFab

--- a/UnrealPlugin/ThirdPersonMPCloudDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPCloudDeploy.md
@@ -1,0 +1,74 @@
+# ThirdPersonMP Example Project Cloud Deployment
+
+The purpose of this guide is the final step, deploying your game to the PlayFab MPS cloud.
+
+## Goals
+
+* Deploy a game to the cloud.
+* Connect to it from a local game client
+
+## Requirements
+
+* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	- Requires Workloads: .NET desktop development, and Desktop development with C++
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
+* [Release Server](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio or Development Editor
+* [Client](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio or Development Editor
+
+## Instructions
+
+### Packaging the game server
+
+Make sure that you have just built your project in development editor in Visual Studio *before* doing this next step, because sometimes building fails when opening the project directly through the .uproject file.
+
+Right click on the .uproject file in your file editor and select "Generate Visual Studio Project Files". 
+
+Then open the .uproject file.
+
+In the top left of the Unreal editor menu, click on File -> Package -> Target Configuration -> [game name]Server and then go to File -> Package -> Windowsx64. 
+You can now use this packaged version of your game server to [test with LocalMultiplayerAgent](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/servers/locally-debugging-game-servers-and-integration-with-playfab) 
+or to use it directly with PlayFab by [creating a build](https://developer.playfab.com/) and then using [PlayFab MpsAllocatorSample](https://github.com/PlayFab/MpsSamples/blob/master/MpsAllocatorSample/README.md).
+
+### Setting up a Windows Dedicated Server on PlayFab
+
+An important note about this is that you need to set the start command in process-based mode to \<root folder\>\\Binaries\\Win64\\\<project name\>Server.exe (or however the executable is called in the folder).
+
+In container-based mode use \<mount folder\>\\\<root folder\>\\Binaries\\Win64\\\<project name\>Server.exe (or however the executable is called in the folder).
+
+**If you use the executable in the root folder, the server will fail to initialize with the PlayFab system.**
+
+### Setting up a Linux Dedicated Server on PlayFab
+
+During testing the following Dockerfile + startup.sh script worked excellent with the PlayFab Linux VM:
+
+#### The Linux Dockerfile:
+
+```Dockerfile
+FROM ubuntu:18.04
+
+# Unreal refuses to run as root user, so we must create a user to run as
+# Docker uses root by default
+RUN useradd --system ue
+USER ue
+
+EXPOSE 7777/udp
+
+WORKDIR /server
+
+COPY --chown=ue:ue . /server
+USER root
+CMD ./startup.sh
+```
+
+### startup.sh bash script:
+
+```bash
+chown -R ue.ue $PF_SERVER_LOG_DIRECTORY
+su ue -c ./<projectname>Server.sh
+```
+Make sure that the line endings in the startup&#46;sh file are LF (\\n) and not CRLF (\\r\\n).
+
+# Navigation
+
+This guide sequence is finished. You can return to the main [Unreal GSDK Plugin](README.md) guide.

--- a/UnrealPlugin/ThirdPersonMPCloudDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPCloudDeploy.md
@@ -22,12 +22,12 @@ This guide explains how to deploy your game to PlayFab Multiplayer Server (MPS) 
 
 Make sure that you have just built your project in development editor in Visual Studio *before* doing this next step, because sometimes building fails when opening the project directly through the .uproject file.
 
-Right click on the .uproject file in your file editor and select "Generate Visual Studio Project Files". 
+Right click on the .uproject file in your file editor and select "Generate Visual Studio Project Files".
 
 Then open the .uproject file.
 
-In the top left of the Unreal editor menu, click on File -> Package -> Target Configuration -> [game name]Server and then go to File -> Package -> Windowsx64. 
-You can now use this packaged version of your game server to [test with LocalMultiplayerAgent](https://docs.microsoft.com/gaming/playfab/features/multiplayer/servers/locally-debugging-game-servers-and-integration-with-playfab) 
+In the top left of the Unreal editor menu, click on File -> Package -> Target Configuration -> [game name]Server and then go to File -> Package -> Windowsx64.
+You can now use this packaged version of your game server to [test with LocalMultiplayerAgent](https://docs.microsoft.com/gaming/playfab/features/multiplayer/servers/locally-debugging-game-servers-and-integration-with-playfab)
 or to use it directly with PlayFab by [creating a build](https://developer.playfab.com/) and then using [PlayFab MpsAllocatorSample](https://github.com/PlayFab/MpsSamples/blob/master/MpsAllocatorSample/README.md).
 
 ### Setting up a Windows Dedicated Server on PlayFab

--- a/UnrealPlugin/ThirdPersonMPCloudDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPCloudDeploy.md
@@ -1,6 +1,6 @@
 # ThirdPersonMP Example Project Cloud Deployment
 
-The purpose of this guide is the final step, deploying your game to the PlayFab MPS cloud.
+This guide explains how to deploy your game to PlayFab Multiplayer Server (MPS) cloud. This is the final step in the entire game server cloud deployment process.
 
 ## Goals
 
@@ -9,9 +9,9 @@ The purpose of this guide is the final step, deploying your game to the PlayFab 
 
 ## Requirements
 
-* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Visual Studio. The [community version](https://visualstudio.microsoft.com/vs/community/) is free.
+	* Required workloads: .NET desktop development and Desktop development with C++
+* Download Unreal Engine Source Code. This plugin was tested on Unreal Engine 4.26.2. For instructions, see [Downloading Unreal Engine Source code (external)](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/).
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
 * [Release Server](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio or Development Editor
 * [Client](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio or Development Editor

--- a/UnrealPlugin/ThirdPersonMPCloudDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPCloudDeploy.md
@@ -67,7 +67,7 @@ CMD ./startup.sh
 chown -R ue.ue $PF_SERVER_LOG_DIRECTORY
 su ue -c ./<projectname>Server.sh
 ```
-Make sure that the line endings in the startup&#46;sh file are LF (\\n) and not CRLF (\\r\\n).
+Make sure that the line endings in the startup.sh file are LF (\\n) and not CRLF (\\r\\n).
 
 # Navigation
 

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -29,7 +29,7 @@ We will add and configure the Playfab Unreal GSDK to your project, and test it l
 
 When using the plugin a few things need to be taken care off.
 
-First, open File Explorer and create a folder called “Plugins” in your games' root directory and in the Plugins folder, create a folder called "PlayFabGSDK". Then, drag all the files from the UnrealPlugin folder in this repo into the Plugins/PlayFabGSDK folder.
+First, open File Explorer and create a folder called "Plugins" in your games' root directory and in the Plugins folder, create a folder called "PlayFabGSDK". Then, drag all the files from the UnrealPlugin folder in this repo into the Plugins/PlayFabGSDK folder.
 
 Open the .uproject file in a text editor of your choice. In the plugins array add the PlayFabGSDK.
 
@@ -74,7 +74,7 @@ currently the source build, select it from the dropdown list and then click OK.
 
 ![image depicting a window that says "Select Unreal Engine Version"](Documentation/SelectUnrealEngineVersion.png)
 
-Right click on the .uproject file again and select “Generate Visual Studio Project Files".
+Right click on the .uproject file again and select "Generate Visual Studio Project Files".
 
 Then, build the project in Visual Studio and start the Editor by selecting the Development Editor configuration.
 
@@ -248,7 +248,6 @@ bool UMyGameInstance::OnGSDKHealthCheck()
     return true;
 }
 ```
-
 
 ## Blueprint implementation
 

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -31,7 +31,7 @@ When using the plugin a few things need to be taken care off.
 
 First, open File Explorer and create a folder called "Plugins" in your games' root directory and in the Plugins folder, create a folder called "PlayFabGSDK". Then, drag all the files from the UnrealPlugin folder in this repo into the Plugins/PlayFabGSDK folder.
 
-Open the .uproject file in a text editor of your choice. In the plugins array add the PlayFabGSDK.
+Open the .uproject file in a text editor of your choice. In the plugins array add the PlayFabGSDK plugin.
 
 See the example below:
 
@@ -68,9 +68,7 @@ Update <modulename>.Build.cs file to add "PlayFabGSDK" into the PublicDependency
 PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "PlayFabGSDK" });
 ```
 
-Right click on the .uproject file and choose the option to "Switch Unreal Engine version", which is how you can quickly check which Unreal Engine version you are currently using. 
-The popup seen below should appear. If you already see that the Unreal Engine version is source build, you don’t need to change anything, so click Cancel. If the Unreal version is not 
-currently the source build, select it from the dropdown list and then click OK. 
+Right click on the .uproject file and choose the option to "Switch Unreal Engine version", which is how you can quickly check which Unreal Engine version you are currently using. The popup seen below should appear. If you already see that the Unreal Engine version is source build, you don’t need to change anything, so click Cancel. If the Unreal version is not currently the source build, select it from the dropdown list and then click OK. 
 
 ![image depicting a window that says "Select Unreal Engine Version"](Documentation/SelectUnrealEngineVersion.png)
 
@@ -84,7 +82,8 @@ Then, build the project in Visual Studio and start the Editor by selecting the D
 
 Once your project has enabled server mode, you will have a <projectname>Server.Target.cs file.
 
-Result should similar to:
+Result should look similar to:
+
 ```csharp 
 public class <projectname>ServerTarget : TargetRules
 {
@@ -99,7 +98,8 @@ public class <projectname>ServerTarget : TargetRules
 }
 ```
 
-For Windows builds, you may need to add these optional configuations:
+For Windows builds, you may need to add these optional configurations:
+
 ```csharp
 DisablePlugins.Add("WMFMediaPlayer");
 DisablePlugins.Add("AsyncLoadingScreen"); //if you are using this plugin
@@ -112,14 +112,11 @@ NOTE: These configurations are invalid for a Linux server build.
 
 #### Creating a GameInstance Class
 
-If you are in the process of creating a game from scratch and do not yet have a GameInstance class, then first follow these example instructions to create a GameInstance class. 
-
-If you are using a game that already has a GameInstance class, (for example, ShooterGame from Unreal's sample library), then move on to the section titled _**Modify the GameInstance Class**_.
+If you are in the process of creating a game from scratch and do not yet have a GameInstance class, then first follow these example instructions to create a GameInstance class. If you are using a game that already has a GameInstance class, (for example, ShooterGame from Unreal's sample library), then move on to the section titled _**Modify the GameInstance Class**_.
 
 ----
 
-In the Unreal Editor, go to Files->Create a new C++ class and select the option to "Show all classes". Then search for GameInstance. 
-By selecting it directly, everything should be generated correctly and then you can add the functions we detail below.
+In the Unreal Editor, go to Files->Create a new C++ class and select the option to "Show all classes". Then search for GameInstance. By selecting it directly, everything should be generated correctly and then you can add the functions we detail below.
 
 Then close Unreal and generate project files in source build mode again.
 
@@ -127,8 +124,7 @@ Then using Visual Studio, open those newly created files and follow instructions
 
 #### Modify the Game Instance Class
 
-Locate your GameInstance class, which is most likely called something similar to [your game name]GameInstance or MyGameInstance. From now on, your game instance class will
-be denoted with [YourGameInstanceClassName].
+Locate your GameInstance class, which is most likely called something similar to [your game name]GameInstance or MyGameInstance. From now on, your game instance class will be denoted with [YourGameInstanceClassName].
 
 ##### Modifying the GameInstance header file
 
@@ -140,8 +136,7 @@ First, check the include statements and ensure that the following are included i
 #include "MyGameInstance.generated.h"
 ```
 
-Then, add the following declarations to the public section:
-(If you already have an Init() function, there is no need to include another declaration)
+Then, add the following declarations to the public section: (If you already have an Init() function, there is no need to include another declaration)
 
 ```cpp
 public:
@@ -151,6 +146,7 @@ public:
 ```
 
 Then, add the following declarations to the protected section of methods:
+
 ```cpp
 protected:
 
@@ -189,11 +185,11 @@ void U[YourGameInstanceClassName]::Init()
     UGSDKUtils::RegisterGSDKShutdownDelegate(OnGsdkShutdown);
     UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck);
 }
-``` 
+```
+
 ----
-If you already **had** an Init() function,
-go to check in [YourGameInstanceClassName].cpp file to see if you have a variable that indicates whether the instance is 
-for a dedicated server. **If you can find this variable**, then add in this in at the end of your Init() function:
+
+If you already **had** an Init() function, go to check in [YourGameInstanceClassName].cpp file to see if you have a variable that indicates whether the instance is for a dedicated server. **If you can find this variable**, then add in this in at the end of your Init() function:
 
 ###### Modifying Existing Init() function
 
@@ -211,8 +207,8 @@ for a dedicated server. **If you can find this variable**, then add in this in a
 		OnStart();
 	}
 ```
-**If you can't find a variable like IsDedicatedServerInstance(),** we still want to make sure that ReadyForPlayers() and onStart() are used when using 
-a dedicated server, so you could wrap the call to ReadyForPlayers() as such at the bottom of the Init function:
+
+**If you can't find a variable like IsDedicatedServerInstance(),** we still want to make sure that ReadyForPlayers() and onStart() are used when using a dedicated server, so you could wrap the call to ReadyForPlayers() as such at the bottom of the Init function:
 
 ```cpp
 #if UE_SERVER
@@ -222,6 +218,7 @@ a dedicated server, so you could wrap the call to ReadyForPlayers() as such at t
     }
 #endif
 ```
+
 ----
 
 Lastly, add these method implementations to the bottom of [YourGameInstanceClassName].cpp file:
@@ -284,6 +281,7 @@ navigate to Maps&Modes on the left side. Scroll to the bottom, and then you can 
 ### In DefaultEngine.ini
 
 Or you can update DefaultEngine.ini file and add this:
+
 ```ini
 [/Script/EngineSettings.GameMapsSettings]
 GameInstanceClass=/Script/[game name].MyGameInstance
@@ -300,6 +298,7 @@ In the editor go to Edit -> Project Settings. In the opened window navigate to P
 ### In DefaultGame.ini
 
 Or you can update DefaultGame.ini to show the following:
+
 ```ini
 [/Script/UnrealEd.ProjectPackagingSettings]
 IncludeAppLocalPrerequisites=True

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -27,11 +27,12 @@ We will add and configure the Playfab Unreal GSDK to your project, and test it l
 
 ### Adding the plugin to the project
 
-When using the plugin a few things need to be taken care off.
+Follow these steps to add the Unreal GSDK to your project:
 
-First, open File Explorer and create a folder called "Plugins" in your games' root directory and in the Plugins folder, create a folder called "PlayFabGSDK". Then, drag all the files from the UnrealPlugin folder in this repo into the Plugins/PlayFabGSDK folder.
-
-Open the .uproject file in a text editor of your choice. In the plugins array add the PlayFabGSDK plugin.
+* Go to your Unreal game project
+* Open File Explorer and create a **Plugins** folder in your games' root directory. In the Plugins folder, create a folder called **PlayFabGSDK.**
+* Go to **{depot}\\GSDK\\gsdk\\UnrealPlugin**. Drag all the files from the **UnrealPlugin** folder into the **Plugins/PlayFabGSDK** folder.
+* Lastly, open your game project's **.uproject** file in a text editor of your choice. In the plugins array, add the "PlayFabGSDK" plugin.
 
 See the example below:
 
@@ -68,7 +69,7 @@ Update <modulename>.Build.cs file to add "PlayFabGSDK" into the PublicDependency
 PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "PlayFabGSDK" });
 ```
 
-Right click on the .uproject file and choose the option to "Switch Unreal Engine version", which is how you can quickly check which Unreal Engine version you are currently using. The popup seen below should appear. If you already see that the Unreal Engine version is source build, you don’t need to change anything, so click Cancel. If the Unreal version is not currently the source build, select it from the dropdown list and then click OK. 
+Right click on the .uproject file and choose the option to "Switch Unreal Engine version", which is how you can quickly check which Unreal Engine version you are currently using. The popup seen below should appear. If you already see that the Unreal Engine version is source build, you don’t need to change anything, so click Cancel. If the Unreal version is not currently the source build, select it from the dropdown list and then click OK.
 
 ![image depicting a window that says "Select Unreal Engine Version"](Documentation/SelectUnrealEngineVersion.png)
 
@@ -84,7 +85,7 @@ Once your project has enabled server mode, you will have a <projectname>Server.T
 
 Result should look similar to:
 
-```csharp 
+```csharp
 public class <projectname>ServerTarget : TargetRules
 {
     public <projectname>ServerTarget( TargetInfo Target) : base(Target)
@@ -152,7 +153,7 @@ protected:
 
     UFUNCTION()
     void OnGSDKShutdown();
-    
+
     UFUNCTION()
     bool OnGSDKHealthCheck();
 };
@@ -160,11 +161,11 @@ protected:
 
 ##### Modifying the GameInstance Cpp file
 
-Then, locate the [YourGameInstanceClassName].cpp file. 
+Then, locate the [YourGameInstanceClassName].cpp file.
 
 Make sure that the following are included:
 
-```cpp 
+```cpp
 #include "[YourGameInstanceClassName].h"
 #include "PlayfabGSDK.h"
 #include "GSDKUtils.h"
@@ -174,7 +175,7 @@ Then locate your Init() function. If you _**don't**_ have an Init() function yet
 
 ###### Creating Init() function
 
-```cpp 
+```cpp
 void U[YourGameInstanceClassName]::Init()
 {
     FOnGSDKShutdown_Dyn OnGsdkShutdown;
@@ -248,29 +249,28 @@ bool UMyGameInstance::OnGSDKHealthCheck()
 
 ## Blueprint implementation
 
-In a folder of your choice in the Content Browser right-click and create a Blueprint class. In the All classes dropdown menu find the GameInstance class. In this example the blueprint is named "BP_GameInstance".
-
-Double-click the blueprint and on the left side hover over the function field and click the Override dropdown. Select the Init function.
-
-Right-click in the graph and add in all register GSDK function. 
-
-For GSDK Shutdown and Maintenance Delegate drag out the a line from the red square, and select "Add Custom Event". 
-
-For "Register GSDK Health Check Delegate" select the "Create Event" in the "Event Dispatchers".
-![PlayFab GSDK Health Check select function](Documentation/BlueprintAddRegisterHealthCheckDelegate.png)
-In the dropdown of the new node "Create matching function". **This is important, as the GSDK Health Check Delegate has a return value.**
-![PlayFab GSDK Health Check select function](Documentation/BlueprintRegisterHealthCheckDelegate.png)
-
-In the function make sure the return boolean value is checked.
-![PlayFab GSDK Health Check function](Documentation/BlueprintGSDKHealthCheckFunction.png)
-
-Don't forget to connect all the nodes to the Event Init node.
-
-In the end add the "Ready for Players" to be able to react to the ready signal of PlayFab.
-![PlayFab GSDK Full Graph](Documentation/BlueprintFullGraph.png)
+* Observe the Content Browser window in the Unreal Editor
+* Pick or create a folder to contain new Blueprints
+* Right-Click and create a Blueprint class
+* In the All classes dropdown menu find your GameInstance class
+	* In this example the blueprint is named "MyGameInstance"
+* Double-click the blueprint
+* On the left side hover over the function field and click the Override dropdown
+* Select the Init function
+* Right-click in the graph and add in all register GSDK function
+* For GSDK Shutdown and Maintenance Delegate drag out the a line from the red square, and select "Add Custom Event"
+* For "Register GSDK Health Check Delegate" select the "Create Event" in the "Event Dispatchers".
+* ![PlayFab GSDK Health Check select function](Documentation/BlueprintAddRegisterHealthCheckDelegate.png)
+* In the dropdown of the new node "Create matching function". **This is important, as the GSDK Health Check Delegate has a return value.**
+* ![PlayFab GSDK Health Check select function](Documentation/BlueprintRegisterHealthCheckDelegate.png)
+* In the function make sure the return boolean value is checked.
+* ![PlayFab GSDK Health Check function](Documentation/BlueprintGSDKHealthCheckFunction.png)
+* Don't forget to connect all the nodes to the Event Init node.
+* In the end add the "Ready for Players" to be able to react to the ready signal of PlayFab.
+* ![PlayFab GSDK Full Graph](Documentation/BlueprintFullGraph.png)
 
 ## Set the Game Instance class
-    
+
 After creating a custom game instance class that integrates with the gsdk, you have to configure your project to actually use this newly created game instance class. There are two ways to do this - either through the Unreal Engine editor or by editing DefaultEngine.ini directly.
 
 ### In the Unreal Editor

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -1,0 +1,315 @@
+# ThirdPersonMP Example - GSDK Project Setup
+
+This guide covers upgrading the finished Unreal ThirdPersonMP template and tutorial project, by adding and configuring the PlayFab GSDK. By following this guide, you will upgrade your existing project so it can be hosted on PlayFab Multiplayer Services.
+
+Please note, your Unreal project must have the following capabilities:
+
+* Networking
+* Multiplayer
+* Dedicated Game-Server
+
+If not, you will need to return to the [ThirdPersonMP Example Project Setup](ThirdPersonMPSetup.md) guide to configure your project as a network-enabled multiplayer game, with dedicated server capabilities.
+
+## Goals
+
+We will add and configure the Playfab Unreal GSDK to your project, and test it locally to verify it is expected to work on PlayFab Multiplayer Services.
+
+## Requirements
+
+- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	- Requires Workloads: .NET desktop development, and Desktop development with C++
+- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+- A completed [ThirdPersonMP Example Project](ThirdPersonMPSetup.md), or a project with similar capabilities
+
+## C++ Implementation
+
+### Adding the plugin to the project
+
+When using the plugin a few things need to be taken care off.
+
+First, open File Explorer and create a folder called “Plugins” in your games' root directory and in the Plugins folder, create a folder called "PlayFabGSDK". Then, drag all the files from the UnrealPlugin folder in this repo into the Plugins/PlayFabGSDK folder.
+
+Open the .uproject file in a text editor of your choice. In the plugins array add the PlayFabGSDK.
+
+See the example below:
+
+```json
+{
+    "FileVersion": 3,
+    "EngineAssociation": "4.26",
+    "Category": "",
+    "Description": "",
+    "Modules": [
+        {
+            "Name": "<projectname>",
+            "Type": "Runtime",
+            "LoadingPhase": "Default",
+            "AdditionalDependencies": [
+                "Engine"
+            ]
+        }
+    ],
+    "Plugins": [                    // Add this if it doesn't exist
+        {                           // Add this
+            "Name": "PlayFabGSDK",  // Add this
+            "Enabled": true         // Add this
+        }                           // Add this
+    ]                               // Add this if it doesn't exist
+}
+```
+
+### Include the plugin in your modules
+
+Update <modulename>.Build.cs file to add "PlayFabGSDK" into the PublicDependencyModuleNames.AddRange(); list as follows:
+
+```csharp
+PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "PlayFabGSDK" });
+```
+
+Right click on the .uproject file and choose the option to "Switch Unreal Engine version", which is how you can quickly check which Unreal Engine version you are currently using. 
+The popup seen below should appear. If you already see that the Unreal Engine version is source build, you don’t need to change anything, so click Cancel. If the Unreal version is not 
+currently the source build, select it from the dropdown list and then click OK. 
+
+![image depicting a window that says "Select Unreal Engine Version"](Documentation/SelectUnrealEngineVersion.png)
+
+Right click on the .uproject file again and select “Generate Visual Studio Project Files".
+
+Then, build the project in Visual Studio and start the Editor by selecting the Development Editor configuration.
+
+![image depicting Visual Studio with the option to build in Development Editor Mode](Documentation/DevelopmentEditor.png)
+
+### Project Setup
+
+Once your project has enabled server mode, you will have a <projectname>Server.Target.cs file.
+
+Result should similar to:
+```csharp 
+public class <projectname>ServerTarget : TargetRules
+{
+    public <projectname>ServerTarget( TargetInfo Target) : base(Target)
+    {
+        Type = TargetType.Server;
+        DefaultBuildSettings = BuildSettingsVersion.V2;
+        ExtraModuleNames.AddRange( new string[] { "<projectname>" } );
+
+	// You may have additional configuration based on your server needs
+    }
+}
+```
+
+For Windows builds, you may need to add these optional configuations:
+```csharp
+DisablePlugins.Add("WMFMediaPlayer");
+DisablePlugins.Add("AsyncLoadingScreen"); //if you are using this plugin
+DisablePlugins.Add("WindowsMoviePlayer");
+DisablePlugins.Add("MediaFoundationMediaPlayer");
+```
+NOTE: These configurations are invalid for a Linux server build.
+
+### Creating/Updating the GameInstance Class
+
+#### Creating a GameInstance Class
+
+If you are in the process of creating a game from scratch and do not yet have a GameInstance class, then first follow these example instructions to create a GameInstance class. 
+
+If you are using a game that already has a GameInstance class, (for example, ShooterGame from Unreal's sample library), then move on to the section titled _**Modify the GameInstance Class**_.
+
+----
+
+In the Unreal Editor, go to Files->Create a new C++ class and select the option to "Show all classes". Then search for GameInstance. 
+By selecting it directly, everything should be generated correctly and then you can add the functions we detail below.
+
+Then close Unreal and generate project files in source build mode again.
+
+Then using Visual Studio, open those newly created files and follow instructions to modify the Game Instance class.
+
+#### Modify the Game Instance Class
+
+Locate your GameInstance class, which is most likely called something similar to [your game name]GameInstance or MyGameInstance. From now on, your game instance class will
+be denoted with [YourGameInstanceClassName].
+
+##### Modifying the GameInstance header file
+
+First, check the include statements and ensure that the following are included in the header file for your GameInstance class ([YourGameInstanceClassName].h):
+
+```cpp
+#include "CoreMinimal.h"
+#include "Engine/GameInstance.h"
+#include "MyGameInstance.generated.h"
+```
+
+Then, add the following declarations to the public section:
+(If you already have an Init() function, there is no need to include another declaration)
+
+```cpp
+public:
+
+    virtual void Init() override;
+    virtual void OnStart() override;
+```
+
+Then, add the following declarations to the protected section of methods:
+```cpp
+protected:
+
+    UFUNCTION()
+    void OnGSDKShutdown();
+    
+    UFUNCTION()
+    bool OnGSDKHealthCheck();
+};
+```
+
+##### Modifying the GameInstance Cpp file
+
+Then, locate the [YourGameInstanceClassName].cpp file. 
+
+Make sure that the following are included:
+
+```cpp 
+#include "[YourGameInstanceClassName].h"
+#include "PlayfabGSDK.h"
+#include "GSDKUtils.h"
+```
+
+Then locate your Init() function. If you _**don't**_ have an Init() function yet, then add in the function as such:
+
+###### Creating Init() function
+
+```cpp 
+void U[YourGameInstanceClassName]::Init()
+{
+    FOnGSDKShutdown_Dyn OnGsdkShutdown;
+    OnGsdkShutdown.BindDynamic(this, &UMyGameInstance::OnGSDKShutdown);
+    FOnGSDKHealthCheck_Dyn OnGsdkHealthCheck;
+    OnGsdkHealthCheck.BindDynamic(this, &UMyGameInstance::OnGSDKHealthCheck);
+
+    UGSDKUtils::RegisterGSDKShutdownDelegate(OnGsdkShutdown);
+    UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck);
+}
+``` 
+----
+If you already **had** an Init() function,
+go to check in [YourGameInstanceClassName].cpp file to see if you have a variable that indicates whether the instance is 
+for a dedicated server. **If you can find this variable**, then add in this in at the end of your Init() function:
+
+###### Modifying Existing Init() function
+
+```cpp
+	if (IsDedicatedServerInstance() == true)
+	{
+		FOnGSDKShutdown_Dyn OnGsdkShutdown;
+		OnGsdkShutdown.BindDynamic(this, &UShooterGameInstance::OnGSDKShutdown);
+		FOnGSDKHealthCheck_Dyn OnGsdkHealthCheck;
+		OnGsdkHealthCheck.BindDynamic(this, &UShooterGameInstance::OnGSDKHealthCheck);
+
+		UGSDKUtils::RegisterGSDKShutdownDelegate(OnGsdkShutdown);
+		UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck);
+
+		OnStart();
+	}
+```
+**If you can't find a variable like IsDedicatedServerInstance(),** we still want to make sure that ReadyForPlayers() and onStart() are used when using 
+a dedicated server, so you could wrap the call to ReadyForPlayers() as such at the bottom of the Init function:
+
+```cpp
+#if UE_SERVER
+    if (!UGSDKUtils::ReadyForPlayers())
+    {
+        FPlatformMisc::RequestExit(false);
+    }
+#endif
+```
+----
+
+Lastly, add these method implementations to the bottom of [YourGameInstanceClassName].cpp file:
+
+```cpp
+void UMyGameInstance::OnStart()
+{
+    UE_LOG(LogTemp, Warning, TEXT("Reached onStart!"));
+    if (!UGSDKUtils::ReadyForPlayers())
+    {
+        FPlatformMisc::RequestExit(false);
+    }
+}
+
+void UMyGameInstance::OnGSDKShutdown()
+{
+    UE_LOG(LogTemp, Warning, TEXT("Shutdown!"));
+    FPlatformMisc::RequestExit(false);
+}
+
+bool UMyGameInstance::OnGSDKHealthCheck()
+{
+    UE_LOG(LogTemp, Warning, TEXT("Healthy!"));
+    return true;
+}
+```
+
+
+## Blueprint implementation
+
+In a folder of your choice in the Content Browser right-click and create a Blueprint class. In the All classes dropdown menu find the GameInstance class. In this example the blueprint is named "BP_GameInstance".
+
+Double-click the blueprint and on the left side hover over the function field and click the Override dropdown. Select the Init function.
+
+Right-click in the graph and add in all register GSDK function. 
+
+For GSDK Shutdown and Maintenance Delegate drag out the a line from the red square, and select "Add Custom Event". 
+
+For "Register GSDK Health Check Delegate" select the "Create Event" in the "Event Dispatchers".
+![PlayFab GSDK Health Check select function](Documentation/BlueprintAddRegisterHealthCheckDelegate.png)
+In the dropdown of the new node "Create matching function". **This is important, as the GSDK Health Check Delegate has a return value.**
+![PlayFab GSDK Health Check select function](Documentation/BlueprintRegisterHealthCheckDelegate.png)
+
+In the function make sure the return boolean value is checked.
+![PlayFab GSDK Health Check function](Documentation/BlueprintGSDKHealthCheckFunction.png)
+
+Don't forget to connect all the nodes to the Event Init node.
+
+In the end add the "Ready for Players" to be able to react to the ready signal of PlayFab.
+![PlayFab GSDK Full Graph](Documentation/BlueprintFullGraph.png)
+
+## Set the Game Instance class
+    
+After creating a custom game instance class that integrates with the gsdk, you have to configure your project to actually use this newly created game instance class. There are two ways to do this - either through the Unreal Engine editor or by editing DefaultEngine.ini directly.
+
+### In the Unreal Editor
+
+In the editor, this can also be set through the UI in the editor. In the editor go to Edit -> Project Settings. From that opened window,
+navigate to Maps&Modes on the left side. Scroll to the bottom, and then you can set the option "Game Instance Class" to your new game instance class directly, and avoid typos.
+
+### In DefaultEngine.ini
+
+Or you can update DefaultEngine.ini file and add this:
+```ini
+[/Script/EngineSettings.GameMapsSettings]
+GameInstanceClass=/Script/[game name].MyGameInstance
+```
+
+## Include Pre-requisites for Windows Dedicated Server
+
+There are two ways to include the app-local prerequisites - either through the Unreal Engine editor or by editing DefaultGame.ini.
+
+### In the Unreal Editor
+
+In the editor go to Edit -> Project Settings. In the opened window navigate to Packaging on the left side. Scroll to the bottom of the list, and tick "Include app-local prerequisites".
+
+### In DefaultGame.ini
+
+Or you can update DefaultGame.ini to show the following:
+```ini
+[/Script/UnrealEd.ProjectPackagingSettings]
+IncludeAppLocalPrerequisites=True
+```
+
+If the category already exists in your DefaultGame.ini, then just add the second line to it. This ensures that all app local dependencies ship with the game as well.
+
+If you are using Continuous Integration (CI), then you could add it to your setup to only turn this flag on when building a dedicated server, so the additional dlls only get added if it is a dedicated server build.
+
+## Navigation
+
+You are now ready to run a [test deployment](ThirdPersonMPLocalDeploy.md) of this project on your local machine.
+
+Alternately, you can return to the main [Unreal GSDK Plugin](README.md#project-gsdk-setup) guide.

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -16,12 +16,12 @@ We will add and configure the Playfab Unreal GSDK to your project, and test it l
 
 ## Requirements
 
-* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	* Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Visual Studio. The [community version](https://visualstudio.microsoft.com/vs/community/) is free.
+	* Required workloads: .NET desktop development and Desktop development with C++
+* Download Unreal Engine Source Code. This plugin was tested on Unreal Engine 4.26.2. For instructions, see [Downloading Unreal Engine Source code (external)](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/).
 * A completed [ThirdPersonMP Example Project](ThirdPersonMPSetup.md), or a project with similar capabilities
 * [PlayFab Unreal GSDK plugin](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
-* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
+* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab). This plugin is not required for GSDK but is required for many PlayFab services, including login.
 
 ## C++ Implementation
 

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -16,10 +16,12 @@ We will add and configure the Playfab Unreal GSDK to your project, and test it l
 
 ## Requirements
 
-- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	- Requires Workloads: .NET desktop development, and Desktop development with C++
-- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
-- A completed [ThirdPersonMP Example Project](ThirdPersonMPSetup.md), or a project with similar capabilities
+* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	* Requires Workloads: .NET desktop development, and Desktop development with C++
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* A completed [ThirdPersonMP Example Project](ThirdPersonMPSetup.md), or a project with similar capabilities
+* [PlayFab Unreal GSDK plugin](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
+* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/en-US/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
 
 ## C++ Implementation
 
@@ -310,6 +312,6 @@ If you are using Continuous Integration (CI), then you could add it to your setu
 
 ## Navigation
 
-You are now ready to run a [test deployment](ThirdPersonMPLocalDeploy.md) of this project on your local machine.
+You are now ready to [build your project](ThirdPersonMPBuild.md) on your local machine.
 
-Alternately, you can return to the main [Unreal GSDK Plugin](README.md#project-gsdk-setup) guide.
+Alternately, you can return to the main [Unreal GSDK Plugin](README.md#unreal_project_build_configurations) guide.

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -18,10 +18,10 @@ We will add and configure the Playfab Unreal GSDK to your project, and test it l
 
 * Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	* Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * A completed [ThirdPersonMP Example Project](ThirdPersonMPSetup.md), or a project with similar capabilities
 * [PlayFab Unreal GSDK plugin](https://github.com/PlayFab/gsdk/tree/master/UnrealPlugin)
-* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/en-US/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
+* [Optional] [PlayFab Marketplace plugin](https://www.unrealengine.com/marketplace/product/playfab-sdk) or the [source version on GitHub](https://github.com/PlayFab/UnrealMarketplacePlugin/tree/master/4.26/PlayFabPlugin/PlayFab) (Not required for GSDK, but required for most other PlayFab services, including login)
 
 ## C++ Implementation
 

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -75,10 +75,10 @@ For the purposes of this guide, the parts of the json file obscured by ```...```
 	* This requirement is a low priority polish item that hasn't been reconsidered yet
 	* For this example, this could be: ```{depot}\\empty.zip```
 	* For the author, this is: ```"M:\\depot\\GSDK\\ThirdPersonMPGSDK\\Binaries\\Win64\\ThirdPersonMPServer.zip```, with an empty zip file at that location
-	* NOTE: When RunContainer==true, the contents of this file will be relevant and used
+	* NOTE: When RunContainer==true, the contents of this file will be relevant and used, and should contain your Shipping Server
 * ContainerStartParameters/StartGameCommand: While RunContainer is false, this is unused.
 	* When RunContainer==true, it supercedes the ProcessStartParameters/StartGameCommand
-	* This path is the internal path within the docker container, and will be the sum of AssetDetails/MountPath, plus the internal path-to-exe in your zip file
+	* This path is the internal path within the docker container, and will be the sum of AssetDetails/MountPath, plus the internal path-to-exe in your zip file defined by AssetDetails/LocalFilePath
 	* For this example, this could be: ```C:\\Assets\\ThirdPersonMPServer.exe -log```
 * ProcessStartParameters/StartGameCommand: This command will effectively be the path to your exe, and any command-line parameters used to start your game server
 	* -log is an Unreal command to instruct the game-server to save an execution log
@@ -92,14 +92,13 @@ Once you have created your zip file and set all of these lines to appropriate va
 
 You can run LocalMultiplayerAgent from Visual Studio with the "Start New Instance" command, sometimes bound to F5, or you can navigate to ```{depot}\LocalMultiplayerAgent\bin\{configuration}\netcoreapp3.1``` and double click "LocalMultiplayerAgent.exe". You can also run this from within a cmd window to observe or capture debug log information.
 
-Running LocalMultiplayerAgent.exe should start your game server. You can find your game server process ID in the Details column. If there are multiple instances, you may need to use Task 
-Manager to force-close instances that are lingering from previous attempts. If your LocalMultiplayerAgent _starts_ multiple instances, look for the process ID with a comparatively high memory use (Some Unreal build configurations have multiple executables, and both are in the task manager for the duration).
+Running LocalMultiplayerAgent.exe should start your game server. You will usually want to have Task Manager open for this. You can find your game server process ID in the Details tab of Task Manager. If there are multiple instances listed, you may need to use Task Manager to force-close instances that are lingering from previous attempts. If your LocalMultiplayerAgent _starts_ multiple instances, look for the process ID with a comparatively high memory use (Some Unreal build configurations have multiple executables, and both are in the task manager for the duration).
 
 Once you see your ThirdPersonMPServer process running in Task Manager, you can return to Visual Studio, select the Debug dropdown -> Attach to Process. From the popup window, you can search your process name: ThirdPersonMPServer, and then select the proper process ID, identified from Task Manager.
 
-At this point, you should be able to perform moderate debugging into your game.
+At this point, you should be able to perform typical debugging into your game server.
 
-NOTE: Unreal provides multiple build configurations and multiple ways to build your server. For best results, use the "Development Server" configuration, and output, built directly from Visual Studio. Release builds, or builds built from the Development Editor may work better for other situations, but the configuration built directly from Visual Studio will be easier to attach, and debug in Visual Studio.
+NOTE: Unreal provides multiple build configurations and multiple ways to build your server. For best results, use the "Development Server" configuration, and output, built directly from Visual Studio. Shipping builds, or builds built from the Development Editor may work better for other situations, but the "Development Server" configuration built directly from Visual Studio will be easier to attach and debug in Visual Studio.
 
 ## Navigation
 

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -60,13 +60,14 @@ In Explorer, find and open the file: ```{depot}\MpsAgent\LocalMultiplayerAgent\M
 }
 ```
 
-The parts of the file obscured by ```...``` above, can be ignored in this guide. The purpose and values for the important fields are as follows:
+For the purposes of this guide, the parts of the json file obscured by ```...``` above, just utilize the project defaults. The purpose and values for the important fields are as follows:
 
 * RunContainer: For this guide, this will always be false. Setting this to true requires Docker.
     * When true, the zip file in <PATH TO ZIP> must contain the entire project server release build
 	* When true, the ProcessStartParameters/StartGameCommand is ignored, and ContainerStartParameters/StartGameCommand is used instead
-	* When true, everything is built and run in a docker container, rather than on the local machine
+	* When true, everything is built and run in a docker container, rather than on the local machine context
 	* This guide covers the scenario when RunContainer is false, so that we can more easily debug the server process
+	* Setting this to true requires a Shipping Server build, additional [Windows](https://docs.adamrehn.com/ue4-docker/configuration/configuring-windows-server) or [Linux](https://unrealcontainers.com/blog/identifying-application-runtime-dependencies/) DLLs, and [Docker for Windows](https://www.docker.com/products/docker-desktop)
 * AssetDetails/LocalFilePath: <PATH TO ZIP>
 	* This location must be fully defined, and a valid zip file must exist at this location
 	* When RunContainer==false, this file is ignored, but its existence is still required

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -73,7 +73,7 @@ For the purposes of this guide, the parts of the json file obscured by ```...```
 	* This location must be fully defined, and a valid zip file must exist at this location
 	* When RunContainer==false, this file is ignored, but its existence is still required
 	* The zip file can be empty
-	* This requirement is a low priority polish item that hasn't been reconsidered yet
+	* This requirement is a low priority polish item that hasn't been resolved yet
 	* For this example, this could be: ```{depot}\\empty.zip```
 	* For the author, this is: ```"M:\\depot\\GSDK\\ThirdPersonMPGSDK\\Binaries\\Win64\\ThirdPersonMPServer.zip```, with an empty zip file at that location
 	* NOTE: When RunContainer==true, the contents of this file will be relevant and used, and should contain your Shipping Server
@@ -93,13 +93,23 @@ Once you have created your zip file and set all of these lines to appropriate va
 
 You can run LocalMultiplayerAgent from Visual Studio with the "Start New Instance" command, sometimes bound to F5, or you can navigate to ```{depot}\LocalMultiplayerAgent\bin\{configuration}\netcoreapp3.1``` and double click "LocalMultiplayerAgent.exe". You can also run this from within a cmd window to observe or capture debug log information.
 
-Running LocalMultiplayerAgent.exe should start your game server. You will usually want to have Task Manager open for this. You can find your game server process ID in the Details tab of Task Manager. If there are multiple instances listed, you may need to use Task Manager to force-close instances that are lingering from previous attempts. If your LocalMultiplayerAgent _starts_ multiple instances, look for the process ID with a comparatively high memory use (Some Unreal build configurations have multiple executables, and both are in the task manager for the duration).
+Running LocalMultiplayerAgent.exe should start your game server. You will usually want to have Task Manager open for this. You can find your game server process ID in the Details tab of Task Manager.
 
 Once you see your ThirdPersonMPServer process running in Task Manager, you can return to Visual Studio, select the Debug dropdown -> Attach to Process. From the popup window, you can search your process name: ThirdPersonMPServer, and then select the proper process ID, identified from Task Manager.
 
 At this point, you should be able to perform typical debugging into your game server.
 
 NOTE: Unreal provides multiple build configurations and multiple ways to build your server. For best results, use the "Development Server" configuration, and output, built directly from Visual Studio. Shipping builds, or builds built from the Development Editor may work better for other situations, but the "Development Server" configuration built directly from Visual Studio will be easier to attach and debug in Visual Studio.
+
+## Troubleshooting
+
+### Many instances of ThirdPersonMPServer in Task Manager
+
+If there are multiple instances listed (usually 3 or more), you may need to use Task Manager to force-close instances that are lingering from previous attempts.
+
+### LocalMultiplayerAgent launches 2 instances of ThirdPersonMPServer
+
+If your LocalMultiplayerAgent _starts_ multiple instances, look for the process ID with a comparatively high memory use. Some configurations of the game server generate two executables, which run as a pair. You will want to attach to the one with a much higher memory use.
 
 ## Navigation
 

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -12,7 +12,7 @@ The purpose of this guide is to demonstrate running your game-server on your loc
 
 * Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
 * ["Development Server"](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio
 * [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -18,7 +18,7 @@ The purpose of this guide is to demonstrate running your game-server on your loc
 * [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)
 	* [Optional] Alternatively, download [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent).
 * "Debug" or "Release" configuration of LocalMultiplayerAgent built from this repo with Visual Studio
-	* Load [MpsAgent.sln](https://github.com/PlayFab/MpsAgent/blob/main/MpsAgent.sln) in Visual Studio, select configuration, build LocalMultiplayerAgent project
+	* Using Visual Studio, Open [MpsAgent.sln](https://github.com/PlayFab/MpsAgent/blob/main/MpsAgent.sln), Select either Debug or Release configuation, and then build the LocalMultiplayerAgent.
 * [Optional] Install [Docker for Windows](https://www.docker.com/products/docker-desktop)
 
 ## Notation

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -39,7 +39,7 @@ First, you will need to configure your LocalMultiplayerAgent to execute your ser
 
 In Explorer, find and open the file: ```{depot}\MpsAgent\LocalMultiplayerAgent\MultiplayerSettings.json```. An abbreviated version of this file with the parts important to this guide are as follows [NOTE the escaped \'s in the paths - this is a json file, and thus it's required to escape all \'s as \\]:
 
-json```
+```json
 {
   "RunContainer": false,
   ...

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -37,7 +37,7 @@ It is not required that you have all of these in the same location, but it is li
 
 First, you will need to configure your LocalMultiplayerAgent to execute your server project. The first iteration will run the process directly on your local PC without any isolation.
 
-In Explorer, find and open the file: ```{depot}\MpsAgent\LocalMultiplayerAgent\MultiplayerSettings.json```. An abbreviated version of this file with the parts important to this guide are as follows [NOTE the escaped \'s in the paths - this is a json file, and thus it's required to escape all \'s as \\]:
+In Explorer, find and open the file: ```{depot}\MpsAgent\LocalMultiplayerAgent\MultiplayerSettings.json```. An abbreviated version of this file with the parts important to this guide are as follows [NOTE the escaped \\'s for paths in the json - this is a json file, and thus it's required to escape all \\'s as \\\\]:
 
 ```json
 {

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -10,13 +10,13 @@ The purpose of this guide is to demonstrate running your game-server on your loc
 
 ## Requirements
 
-* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Visual Studio. The [community version](https://visualstudio.microsoft.com/vs/community/) is free.
+	* Required workloads: .NET desktop development and Desktop development with C++
+* Download Unreal Engine Source Code. This plugin was tested on Unreal Engine 4.26.2. For instructions, see [Downloading Unreal Engine Source code (external)](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/).
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
 * ["Development Server"](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio
 * [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)
-	* [Optional] Alternately, download the [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
+	* [Optional] Alternatively, download [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent).
 * "Debug" or "Release" configuration of LocalMultiplayerAgent built from this repo with Visual Studio
 	* Load [MpsAgent.sln](https://github.com/PlayFab/MpsAgent/blob/main/MpsAgent.sln) in Visual Studio, select configuration, build LocalMultiplayerAgent project
 * [Optional] Install [Docker for Windows](https://www.docker.com/products/docker-desktop)

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -15,7 +15,8 @@ The purpose of this guide is to demonstrate running your game-server on your loc
 * Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
 * ["Development Server"](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio
-* Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
+* [Optional] Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/releases)
+	* [Optional] Alternately, download the [LocalMultiplayerAgent source](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
 * "Debug" or "Release" configuration of LocalMultiplayerAgent built from this repo with Visual Studio
 	* Load [MpsAgent.sln](https://github.com/PlayFab/MpsAgent/blob/main/MpsAgent.sln) in Visual Studio, select configuration, build LocalMultiplayerAgent project
 * [Optional] Install [Docker for Windows](https://www.docker.com/products/docker-desktop)

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -4,7 +4,9 @@ The purpose of this guide is to demonstrate running your game-server on your loc
 
 ## Goals
 
-Test the local deployment options for the ThirdPersonMP+GSDK project.
+* Test the local deployment options for the ThirdPersonMP+GSDK project.
+* Verify your server executes properly when run using LocalMultiplayerAgent
+* Verify you can attach a debugger to your server instance
 
 ## Requirements
 
@@ -12,14 +14,97 @@ Test the local deployment options for the ThirdPersonMP+GSDK project.
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
 - Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
+
+!!!TODO new guide: Build instructions for development editor, client, development server, and release server!!!
+* "Development Server" configuration of your project built from Visual Studio
+
 * Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
+* "Debug" or "Release" configuration of LocalMultiplayerAgent built from this repo with Visual Studio
+	* Load [MpsAgent.sln](https://github.com/PlayFab/MpsAgent/blob/main/MpsAgent.sln) in Visual Studio, select configuration, build LocalMultiplayerAgent project
+* [Optional] Install [Docker for Windows](https://www.docker.com/products/docker-desktop)
+
+## Notation
+
+{depot} will refer to the full windows path for the location where you download your Git projects. These can be anywhere you like, such as: C:\depot, S:\depot, Z:\gitrepos or whichever drive and path is convienient for you. It is typically recommended (especially for Unreal), that your {depot} path be very short, if possible. For the author, {depot} resolves to: ```M:\\depot\\GSDK```. For example, with the requirements list above, you will likely have some or all of the following:
+
+* {depot}/ThirdPersonMP
+* {depot}/MpsAgent
+* [Optional] {depot}/gsdk [This contains the PlayFab Unreal GSDK plugin previously installed into ThirdPersonMP]
+* [Optional] {depot}/UnrealMarketplacePlugin  [This contains the PlayFab Unreal Marketplace plugin, which is not required for MPS, but almost certainly required for other PlayFab features]
+
+It is not required that you have all of these in the same location, but it is likely useful to do so, and for organization, this guide encourages you to do so.
 
 ## Instructions
 
-TODO
+### Local execution, no containers
+
+First, you will need to configure your LocalMultiplayerAgent to execute your server project. The first iteration will run the process directly on your local PC without any isolation.
+
+In Explorer, find and open the file: ```{depot}\MpsAgent\LocalMultiplayerAgent\MultiplayerSettings.json```. An abbreviated version of this file with the parts important to this guide are as follows [NOTE the escaped \'s in the paths - this is a json file, and thus it's required to escape all \'s as \\]:
+
+json```
+{
+  "RunContainer": false,
+  ...
+  "AssetDetails": [
+    {
+      "MountPath": "C:\\Assets",
+      "LocalFilePath": "<PATH TO ZIP>"
+    }
+  ],
+  ...
+  "ProcessStartParameters": {
+    "StartGameCommand": "<PATH TO EXE> -log"
+  },
+  "ContainerStartParameters": {
+    "StartGameCommand": "C:\\Assets\\ThirdPersonMPServer.exe -log",
+	...
+  }
+}
+```
+
+The parts of the file obscured by ```...``` above, can be ignored in this guide. The purpose and values for the important fields are as follows:
+
+* RunContainer: For this guide, this will always be false. Setting this to true requires Docker.
+    * When true, the zip file in <PATH TO ZIP> must contain the entire project server release build
+	* When true, the ProcessStartParameters/StartGameCommand is ignored, and ContainerStartParameters/StartGameCommand is used instead
+	* When true, everything is built and run in a docker container, rather than on the local machine
+	* This guide covers the scenario when RunContainer is false, so that we can more easily debug the server process
+* AssetDetails/LocalFilePath: <PATH TO ZIP>
+	* This location must be fully defined, and a valid zip file must exist at this location
+	* When RunContainer==false, this file is ignored, but its existence is still required
+	* The zip file can be empty
+	* This requirement is a low priority polish item that hasn't been reconsidered yet
+	* For this example, this could be: ```{depot}\\empty.zip```
+	* For the author, this is: ```"M:\\depot\\GSDK\\ThirdPersonMPGSDK\\Binaries\\Win64\\ThirdPersonMPServer.zip```, with an empty zip file at that location
+	* NOTE: When RunContainer==true, the contents of this file will be relevant and used
+* ContainerStartParameters/StartGameCommand: While RunContainer is false, this is unused.
+	* When RunContainer==true, it supercedes the ProcessStartParameters/StartGameCommand
+	* This path is the internal path within the docker container, and will be the sum of AssetDetails/MountPath, plus the internal path-to-exe in your zip file
+	* For this example, this could be: ```C:\\Assets\\ThirdPersonMPServer.exe -log```
+* ProcessStartParameters/StartGameCommand: This command will effectively be the path to your exe, and any command-line parameters used to start your game server
+	* -log is an Unreal command to instruct the game-server to save an execution log
+	* <PATH TO EXE> can be any local path to the exe for your game server, plus any command line parameters for your server
+	* For this example, this could be: ```{depot}\\ThirdPersonMP\\Binaries\\Win64\\ThirdPersonMPServer.exe -log```
+	* For the author, this is: ```M:\\depot\\GSDK\\ThirdPersonMPGSDK\\Binaries\\Win64\\ThirdPersonMPServer.exe -log```
+
+Once you have created your zip file and set all of these lines to appropriate values, you can rebuild your LocalMultiplayerAgent, and prepare to debug your server.
+
+### Debugging your server
+
+You can run LocalMultiplayerAgent from Visual Studio with the "Start New Instance" command, sometimes bound to F5, or you can navigate to ```{depot}\LocalMultiplayerAgent\bin\{configuration}\netcoreapp3.1``` and double click "LocalMultiplayerAgent.exe". You can also run this from within a cmd window to observe or capture debug log information.
+
+Running LocalMultiplayerAgent.exe should start your game server. You can find your game server process ID in the Details column. If there are multiple instances, you may need to use Task 
+Manager to force-close instances that are lingering from previous attempts. If your LocalMultiplayerAgent _starts_ multiple instances, look for the process ID with a comparatively high memory use (Some Unreal build configurations have multiple executables, and both are in the task manager for the duration).
+
+Once you see your ThirdPersonMPServer process running in Task Manager, you can return to Visual Studio, select the Debug dropdown -> Attach to Process. From the popup window, you can search your process name: ThirdPersonMPServer, and then select the proper process ID, identified from Task Manager.
+
+At this point, you should be able to perform moderate debugging into your game.
+
+NOTE: Unreal provides multiple build configurations and multiple ways to build your server. For best results, use the "Development Server" configuration, and output, built directly from Visual Studio. Release builds, or builds built from the Development Editor may work better for other situations, but the configuration built directly from Visual Studio will be easier to attach, and debug in Visual Studio.
 
 ## Navigation
 
-You are now ready to [deploy your game server](ThirdPersonMPLocalDeploy.md) to PlayFab MPS and test your project in the cloud.
+You are now ready to ... TODO LINK TO THE NEXT DOCUMENT
 
 Alternately, you can return to the main [Unreal GSDK Plugin](README.md#deploy-to-playfab) guide.

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -1,4 +1,4 @@
-# ThirdPersonMP Example Project Deployment
+# ThirdPersonMP Example Project Local Deployment and Debugging
 
 The purpose of this guide is to demonstrate running your game-server on your local machine, in a MPS-compliant way, so you can test and debug your server before uploading it to PlayFab.
 
@@ -10,14 +10,11 @@ The purpose of this guide is to demonstrate running your game-server on your loc
 
 ## Requirements
 
-- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 * [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
-
-!!!TODO new guide: Build instructions for development editor, client, development server, and release server!!!
-* "Development Server" configuration of your project built from Visual Studio
-
+* ["Development Server"](ThirdPersonMPBuild.md) configuration of your project built from Visual Studio
 * Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
 * "Debug" or "Release" configuration of LocalMultiplayerAgent built from this repo with Visual Studio
 	* Load [MpsAgent.sln](https://github.com/PlayFab/MpsAgent/blob/main/MpsAgent.sln) in Visual Studio, select configuration, build LocalMultiplayerAgent project
@@ -25,12 +22,12 @@ The purpose of this guide is to demonstrate running your game-server on your loc
 
 ## Notation
 
-{depot} will refer to the full windows path for the location where you download your Git projects. These can be anywhere you like, such as: C:\depot, S:\depot, Z:\gitrepos or whichever drive and path is convienient for you. It is typically recommended (especially for Unreal), that your {depot} path be very short, if possible. For the author, {depot} resolves to: ```M:\\depot\\GSDK```. For example, with the requirements list above, you will likely have some or all of the following:
+{depot} will refer to the full windows path for the location where you download your Git projects. These can be anywhere you like, such as: C:\depot, S:\depot, Z:\gitrepos or whichever drive and path is convienient for you. It is typically recommended (especially for Unreal), that your {depot} path be very short, if possible. For the author, {depot} resolves to: ```M:\depot\GSDK```. For example, with the requirements list above, you will likely have some or all of the following:
 
 * {depot}/ThirdPersonMP
 * {depot}/MpsAgent
 * [Optional] {depot}/gsdk [This contains the PlayFab Unreal GSDK plugin previously installed into ThirdPersonMP]
-* [Optional] {depot}/UnrealMarketplacePlugin  [This contains the PlayFab Unreal Marketplace plugin, which is not required for MPS, but almost certainly required for other PlayFab features]
+* [Optional] {depot}/UnrealMarketplacePlugin  [This contains the PlayFab Unreal Marketplace plugin, which is not required for this guide, but almost certainly required for other PlayFab features]
 
 It is not required that you have all of these in the same location, but it is likely useful to do so, and for organization, this guide encourages you to do so.
 
@@ -105,6 +102,6 @@ NOTE: Unreal provides multiple build configurations and multiple ways to build y
 
 ## Navigation
 
-You are now ready to ... TODO LINK TO THE NEXT DOCUMENT
+You are now ready to deploy [your server to the cloud](ThirdPersonMPCloudDeploy.md).
 
 Alternately, you can return to the main [Unreal GSDK Plugin](README.md#deploy-to-playfab) guide.

--- a/UnrealPlugin/ThirdPersonMPLocalDeploy.md
+++ b/UnrealPlugin/ThirdPersonMPLocalDeploy.md
@@ -1,0 +1,25 @@
+# ThirdPersonMP Example Project Deployment
+
+The purpose of this guide is to demonstrate running your game-server on your local machine, in a MPS-compliant way, so you can test and debug your server before uploading it to PlayFab.
+
+## Goals
+
+Test the local deployment options for the ThirdPersonMP+GSDK project.
+
+## Requirements
+
+- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	- Requires Workloads: .NET desktop development, and Desktop development with C++
+- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* [Completed Unreal Project](ThirdPersonMPSetup.md) with [PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) installed and configured
+* Download the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent/tree/main/LocalMultiplayerAgent)
+
+## Instructions
+
+TODO
+
+## Navigation
+
+You are now ready to [deploy your game server](ThirdPersonMPLocalDeploy.md) to PlayFab MPS and test your project in the cloud.
+
+Alternately, you can return to the main [Unreal GSDK Plugin](README.md#deploy-to-playfab) guide.

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -26,4 +26,4 @@ Once finished with the above guide, you will have a working multiplayer game cli
 
 Once finished with both guides, you will have a network-enabled multiplayer game with a dedicated game server.
 
-You can now proceed to install PlayFab MPS using the [Unreal GSDK Plugin](UnrealPlugin/README.md) guide.
+You can now proceed to install PlayFab MPS using the [Unreal GSDK Plugin](README.md) guide.

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -18,17 +18,17 @@ To accomplish this, we will construct a project from scratch using Unreal tutori
 
 * Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 
 ## Instructions
 
-All of the necessary instructions are in the Unreal Tutorials. First, download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions).
+All of the necessary instructions are in the Unreal Tutorials. First, download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions).
 
-Next, you should follow the Unreal [Third Person Template](https://docs.unrealengine.com/4.27/en-US/Resources/Templates/ThirdPerson/) tutorial. This covers the creation of a basic project we will use for the rest of this document.
+Next, you should follow the Unreal [Third Person Template](https://docs.unrealengine.com/4.27/Resources/Templates/ThirdPerson/) tutorial. This covers the creation of a basic project we will use for the rest of this document.
 
-Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial. Note, the first step of this tutorial is an abbreviated version of the one above. This guide upgrades the ThirdPersonMP template to a multiplayer project.
+Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/InteractiveExperiences/Networking/QuickStart/) tutorial. Note, the first step of this tutorial is an abbreviated version of the one above. This guide upgrades the ThirdPersonMP template to a multiplayer project.
 
-Once finished with the above guides, you will have a working multiplayer game client. Next, you need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial. This will set up a dedicated server for your project, and concludes our list of requirements.
+Once finished with the above guides, you will have a working multiplayer game client. Next, you need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial. This will set up a dedicated server for your project, and concludes our list of requirements.
 
 Once finished with all guides, you will have a network-enabled multiplayer project with a dedicated game server.
 

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -16,9 +16,9 @@ To accomplish this, we will construct a project from scratch using Unreal tutori
 
 ## Requirements
 
-- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
 	- Requires Workloads: .NET desktop development, and Desktop development with C++
-- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 
 ## Instructions
 

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -16,9 +16,9 @@ To accomplish this, we will construct a project from scratch using Unreal tutori
 
 ## Requirements
 
-* Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
-	- Requires Workloads: .NET desktop development, and Desktop development with C++
-* Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
+* Download Visual Studio. The [community version](https://visualstudio.microsoft.com/vs/community/) is free.
+	* Required workloads: .NET desktop development and Desktop development with C++
+* Download Unreal Engine Source Code. This plugin was tested on Unreal Engine 4.26.2. For instructions, see [Downloading Unreal Engine Source code (external)](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/).
 
 ## Instructions
 

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -1,6 +1,6 @@
 # ThirdPersonMP Example Project Setup
 
-This guide coveres the construction of an example project which can operate as a game-client and game-server. This will set up the minimum requirements for an Unreal game that can be hosted on PlayFab Multiplayer Services.
+This guide coveres the construction of an example project which can operate as a game-client and dedicated game-server. This will set up the minimum requirements for an Unreal game that can be hosted on PlayFab Multiplayer Services.
 
 ## Goals
 
@@ -9,7 +9,6 @@ The project needs to have the following capabilities and features:
 * Networking
 * Multiplayer
 * Dedicated Game-Server
-* PlayFab MPS Support -- ??? NEXT GUIDE ?!?
 
 To accomplish this, we will construct a project from scratch using Unreal tutorials.
 
@@ -24,7 +23,7 @@ All of the necessary instructions are in the Unreal Tutorials. First, download U
 
 Next, you should follow the Unreal [Third Person Template](https://docs.unrealengine.com/4.27/en-US/Resources/Templates/ThirdPerson/) tutorial. This creates the basic project we will use for the rest of this document.
 
-Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial. NOTE, the first step of this tutorial is an abbreviated version of the one above. It upgrades the ThirdPerson project to a multiplayer project.
+Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial. Note, the first step of this tutorial is an abbreviated version of the one above. This guide upgrades the ThirdPersonMP project to a multiplayer project.
 
 Once finished with the above guides, you will have a working multiplayer game client. Next, we need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial.
 

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -1,6 +1,8 @@
 # ThirdPersonMP Example Project Setup
 
-This guide coveres the construction of an example project which can operate as a game-client and dedicated game-server. This will set up the minimum requirements for an Unreal game that can be hosted on PlayFab Multiplayer Services.
+This guide covers the construction of an example project which can operate as a game-client and dedicated game-server. This will set up the minimum requirements for an Unreal project, before the GSDK can be integrated.
+
+This guide is an excellent starting point if you are starting from scratch.
 
 ## Goals
 
@@ -14,19 +16,24 @@ To accomplish this, we will construct a project from scratch using Unreal tutori
 
 ## Requirements
 
-* Visual Studio Community 2019
-* Unreal 4.26.2 Engine Source
+- Download Visual Studio (the [community version is free](https://visualstudio.microsoft.com/vs/community/))
+	- Requires Workloads: .NET desktop development, and Desktop development with C++
+- Download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions)
 
 ## Instructions
 
 All of the necessary instructions are in the Unreal Tutorials. First, download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions).
 
-Next, you should follow the Unreal [Third Person Template](https://docs.unrealengine.com/4.27/en-US/Resources/Templates/ThirdPerson/) tutorial. This creates the basic project we will use for the rest of this document.
+Next, you should follow the Unreal [Third Person Template](https://docs.unrealengine.com/4.27/en-US/Resources/Templates/ThirdPerson/) tutorial. This covers the creation of a basic project we will use for the rest of this document.
 
-Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial. Note, the first step of this tutorial is an abbreviated version of the one above. This guide upgrades the ThirdPersonMP project to a multiplayer project.
+Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial. Note, the first step of this tutorial is an abbreviated version of the one above. This guide upgrades the ThirdPersonMP template to a multiplayer project.
 
-Once finished with the above guides, you will have a working multiplayer game client. Next, we need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial. This will set up a dedicated server for your game, and concludes our list of requirements.
+Once finished with the above guides, you will have a working multiplayer game client. Next, you need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial. This will set up a dedicated server for your project, and concludes our list of requirements.
 
-Once finished with all guides, you will have a network-enabled multiplayer game with a dedicated game server.
+Once finished with all guides, you will have a network-enabled multiplayer project with a dedicated game server.
 
-You can now return to the [Unreal GSDK Plugin](README.md#project-setup) guide and continue your PlayFab MPS setup by installing the PlayFab Unreal GSDK.
+## Navigation
+
+You are now ready to [install the PlayFab Unreal GSDK](ThirdPersonMPGSDKSetup.md) into this project.
+
+Alternately, you can return to the main [Unreal GSDK Plugin](README.md#project-gsdk-setup) guide.

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -25,7 +25,7 @@ Next, you should follow the Unreal [Third Person Template](https://docs.unrealen
 
 Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial. Note, the first step of this tutorial is an abbreviated version of the one above. This guide upgrades the ThirdPersonMP project to a multiplayer project.
 
-Once finished with the above guides, you will have a working multiplayer game client. Next, we need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial.
+Once finished with the above guides, you will have a working multiplayer game client. Next, we need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial. This will set up a dedicated server for your game, and concludes our list of requirements.
 
 Once finished with all guides, you will have a network-enabled multiplayer game with a dedicated game server.
 

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -1,0 +1,29 @@
+# ThirdPersonMP Example Project Setup
+
+This guide coveres the construction of an example project which can operate as a game-client and game-server, and is configured to operate on PlayFab Multiplayer Services.
+
+## Goals
+
+The project needs to have the following capabilities and features:
+
+* Networking
+* Multiplayer
+* Dedicated Game-Server
+* PlayFab MPS Support -- ??? NEXT GUIDE ?!?
+
+To accomplish this, we will construct a project from scratch using Unreal tutorials.
+
+## Requirements
+
+* Visual Studio Community 2019
+* Unreal 4.26.2 Engine Source
+
+## Instructions
+
+All of the necessary instructions are in the Unreal Tutorials. First, you should download/configure the 4.26.2 Unreal Engine source. Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial.
+
+Once finished with the above guide, you will have a working multiplayer game client. Next, we need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial.
+
+Once finished with both guides, you will have a network-enabled multiplayer game with a dedicated game server.
+
+You can now proceed to install PlayFab MPS using the [Unreal GSDK Plugin](UnrealPlugin/README.md) guide.

--- a/UnrealPlugin/ThirdPersonMPSetup.md
+++ b/UnrealPlugin/ThirdPersonMPSetup.md
@@ -1,6 +1,6 @@
 # ThirdPersonMP Example Project Setup
 
-This guide coveres the construction of an example project which can operate as a game-client and game-server, and is configured to operate on PlayFab Multiplayer Services.
+This guide coveres the construction of an example project which can operate as a game-client and game-server. This will set up the minimum requirements for an Unreal game that can be hosted on PlayFab Multiplayer Services.
 
 ## Goals
 
@@ -20,10 +20,14 @@ To accomplish this, we will construct a project from scratch using Unreal tutori
 
 ## Instructions
 
-All of the necessary instructions are in the Unreal Tutorials. First, you should download/configure the 4.26.2 Unreal Engine source. Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial.
+All of the necessary instructions are in the Unreal Tutorials. First, download Unreal Engine Source Build by following [these instructions](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/) from the Unreal Engine website. This was tested on [4.26.2](https://github.com/EpicGames/UnrealEngine/releases/tag/4.26.2-release) (Link requires permissions).
 
-Once finished with the above guide, you will have a working multiplayer game client. Next, we need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial.
+Next, you should follow the Unreal [Third Person Template](https://docs.unrealengine.com/4.27/en-US/Resources/Templates/ThirdPerson/) tutorial. This creates the basic project we will use for the rest of this document.
 
-Once finished with both guides, you will have a network-enabled multiplayer game with a dedicated game server.
+Then, you should proceed to the Unreal [Multiplayer Programming Quick Start](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/QuickStart/) tutorial. NOTE, the first step of this tutorial is an abbreviated version of the one above. It upgrades the ThirdPerson project to a multiplayer project.
 
-You can now proceed to install PlayFab MPS using the [Unreal GSDK Plugin](README.md) guide.
+Once finished with the above guides, you will have a working multiplayer game client. Next, we need a dedicated server. At this point, you should proceed to the Unreal [Setting Up Dedicated Servers](https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/HowTo/DedicatedServers/) tutorial.
+
+Once finished with all guides, you will have a network-enabled multiplayer game with a dedicated game server.
+
+You can now return to the [Unreal GSDK Plugin](README.md#project-setup) guide and continue your PlayFab MPS setup by installing the PlayFab Unreal GSDK.


### PR DESCRIPTION
First, the main readme page is now just sequential list linking the other pages.
Each other page has a specific limited scope and goal.
The other pages sequentially link to each next page, and back to the main page.
Previous details that were in the singular readme are transferred to the individual section documents.
New documents are created to cover gaps in the setup which were previously just assumed.