### PR TITLE
Renamed local variable

### DIFF
--- a/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKConfiguration.cpp
+++ b/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKConfiguration.cpp
@@ -185,9 +185,9 @@ FJsonFileConfiguration::FJsonFileConfiguration(const FString& FileName)
 	if (ConfigJson->HasField(TEXT("gamePorts")))
 	{
 		TSharedPtr<FJsonObject> GamePortsJson = ConfigJson->GetObjectField(TEXT("gamePorts"));
-		for (const auto& GamePort: GamePortsJson->Values)
+		for (const auto& GamePortCur: GamePortsJson->Values)
 		{
-			Ports.Add(GamePort.Key, GamePort.Value->AsString());
+			Ports.Add(GamePortCur.Key, GamePortCur.Value->AsString());
 		}
 	}
 

--- a/UnrealPlugin/ThirdPersonMPGSDKSetup.md
+++ b/UnrealPlugin/ThirdPersonMPGSDKSetup.md
@@ -169,7 +169,6 @@ protected:
 
     UFUNCTION()
     void OnGSDKReadyForPlayers();
-};
 ```
 
 ##### Modifying the GameInstance Cpp file


### PR DESCRIPTION
The name GamePort collides with global definition introduced in UE5 release version.