### PR TITLE
Added -nogsdk flag to allow local ue server testing without MPS agent

### DIFF
--- a/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKUtils.cpp
+++ b/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKUtils.cpp
@@ -176,6 +176,9 @@ FString UGSDKUtils::GetConfigValue(const FString& Key)
 
 bool UGSDKUtils::SetDefaultServerHostPort()
 {
+	//If we're running a local test server then we don't want to check the host port as the MPS won't be present
+	if(FPlayFabGSDKModule::Get().GetIsUsingGsdk() == false) return true;
+
 	auto ConnectionInfo = GetGameServerConnectionInfo();
 	// Override the internal Unreal Game Server hosting port number, with one driven from Game Manager
 	// A game server hosted in MPS won't be accessible by clients unless it uses the port that MPS has configured for it.

--- a/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKUtils.cpp
+++ b/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKUtils.cpp
@@ -177,7 +177,7 @@ FString UGSDKUtils::GetConfigValue(const FString& Key)
 bool UGSDKUtils::SetDefaultServerHostPort()
 {
 	//If we're running a local test server then we don't want to check the host port as the MPS won't be present
-	if(!FPlayFabGSDKModule::Get().GetIsUsingGsdk()) return true;
+	if (!FPlayFabGSDKModule::Get().GetIsUsingGsdk()) return true;
 
 	auto ConnectionInfo = GetGameServerConnectionInfo();
 	// Override the internal Unreal Game Server hosting port number, with one driven from Game Manager

--- a/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKUtils.cpp
+++ b/UnrealPlugin/Source/PlayfabGSDK/Private/GSDKUtils.cpp
@@ -177,7 +177,7 @@ FString UGSDKUtils::GetConfigValue(const FString& Key)
 bool UGSDKUtils::SetDefaultServerHostPort()
 {
 	//If we're running a local test server then we don't want to check the host port as the MPS won't be present
-	if(FPlayFabGSDKModule::Get().GetIsUsingGsdk() == false) return true;
+	if(!FPlayFabGSDKModule::Get().GetIsUsingGsdk()) return true;
 
 	auto ConnectionInfo = GetGameServerConnectionInfo();
 	// Override the internal Unreal Game Server hosting port number, with one driven from Game Manager

--- a/UnrealPlugin/Source/PlayfabGSDK/Private/PlayfabGSDK.cpp
+++ b/UnrealPlugin/Source/PlayfabGSDK/Private/PlayfabGSDK.cpp
@@ -35,7 +35,7 @@ DEFINE_LOG_CATEGORY(LogPlayFabGSDK);
 void FPlayFabGSDKModule::StartupModule()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(FParse::Param(FCommandLine::Get(), TEXT("noGSDK")) || FParse::Param(FCommandLine::Get(), TEXT("nogsdk")))
+	if (FParse::Param(FCommandLine::Get(), TEXT("noGSDK")) || FParse::Param(FCommandLine::Get(), TEXT("nogsdk")))
 	{
 		UE_LOG(LogPlayFabGSDK, Display, TEXT("Found noGSDK flag in launch args, no GSDK calls will be made."));
 		NoGSDK = true;
@@ -93,7 +93,7 @@ void FPlayFabGSDKModule::ShutdownModule()
 void FPlayFabGSDKModule::ReadyForPlayers()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(NoGSDK) return;
+	if (NoGSDK) return;
 	GSDKInternal->ReadyForPlayers();
 #endif
 }
@@ -101,7 +101,7 @@ void FPlayFabGSDKModule::ReadyForPlayers()
 const FGameServerConnectionInfo FPlayFabGSDKModule::GetGameServerConnectionInfo()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(NoGSDK) return FGameServerConnectionInfo();
+	if (NoGSDK) return FGameServerConnectionInfo();
 	return GSDKInternal->GetConnectionInfo();
 #else
 	return FGameServerConnectionInfo();
@@ -111,7 +111,7 @@ const FGameServerConnectionInfo FPlayFabGSDKModule::GetGameServerConnectionInfo(
 FString FPlayFabGSDKModule::GetConfigValue(const FString& Key)
 {
 #if PLAYFAB_GSDK_SERVER
-	if(NoGSDK) return TEXT("");
+	if (NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(Key);
 #else
 	return TEXT("");
@@ -121,7 +121,7 @@ FString FPlayFabGSDKModule::GetConfigValue(const FString& Key)
 void FPlayFabGSDKModule::UpdateConnectedPlayers(const TArray<FConnectedPlayer>& CurrentlyConnectedPlayers)
 {
 #if PLAYFAB_GSDK_SERVER
-	if(NoGSDK) return;
+	if (NoGSDK) return;
 	GSDKInternal->SetConnectedPlayers(CurrentlyConnectedPlayers);
 #endif
 }
@@ -129,7 +129,7 @@ void FPlayFabGSDKModule::UpdateConnectedPlayers(const TArray<FConnectedPlayer>& 
 const FString FPlayFabGSDKModule::GetLogsDirectory()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(NoGSDK) return TEXT("");
+	if (NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(LOG_FOLDER_KEY);
 #endif
 	return TEXT("");
@@ -138,7 +138,7 @@ const FString FPlayFabGSDKModule::GetLogsDirectory()
 const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(NoGSDK) return TEXT("");
+	if (NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(SHARED_CONTENT_FOLDER_KEY);
 #endif
 
@@ -148,7 +148,7 @@ const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 const TArray<FString> FPlayFabGSDKModule::GetInitialPlayers()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(NoGSDK) return TArray<FString>();
+	if (NoGSDK) return TArray<FString>();
 	return GSDKInternal->GetInitialPlayers();
 #else
 	return TArray<FString>();

--- a/UnrealPlugin/Source/PlayfabGSDK/Private/PlayfabGSDK.cpp
+++ b/UnrealPlugin/Source/PlayfabGSDK/Private/PlayfabGSDK.cpp
@@ -38,7 +38,7 @@ void FPlayFabGSDKModule::StartupModule()
 	if(FParse::Param(FCommandLine::Get(), TEXT("noGSDK")) || FParse::Param(FCommandLine::Get(), TEXT("nogsdk")))
 	{
 		UE_LOG(LogPlayFabGSDK, Display, TEXT("Found noGSDK flag in launch args, no GSDK calls will be made."));
-		bNoGSDK = true;
+		NoGSDK = true;
 		return;
 	}
 	
@@ -93,7 +93,7 @@ void FPlayFabGSDKModule::ShutdownModule()
 void FPlayFabGSDKModule::ReadyForPlayers()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(bNoGSDK) return;
+	if(NoGSDK) return;
 	GSDKInternal->ReadyForPlayers();
 #endif
 }
@@ -101,7 +101,7 @@ void FPlayFabGSDKModule::ReadyForPlayers()
 const FGameServerConnectionInfo FPlayFabGSDKModule::GetGameServerConnectionInfo()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(bNoGSDK) return FGameServerConnectionInfo();
+	if(NoGSDK) return FGameServerConnectionInfo();
 	return GSDKInternal->GetConnectionInfo();
 #else
 	return FGameServerConnectionInfo();
@@ -111,7 +111,7 @@ const FGameServerConnectionInfo FPlayFabGSDKModule::GetGameServerConnectionInfo(
 FString FPlayFabGSDKModule::GetConfigValue(const FString& Key)
 {
 #if PLAYFAB_GSDK_SERVER
-	if(bNoGSDK) return TEXT("");
+	if(NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(Key);
 #else
 	return TEXT("");
@@ -121,7 +121,7 @@ FString FPlayFabGSDKModule::GetConfigValue(const FString& Key)
 void FPlayFabGSDKModule::UpdateConnectedPlayers(const TArray<FConnectedPlayer>& CurrentlyConnectedPlayers)
 {
 #if PLAYFAB_GSDK_SERVER
-	if(bNoGSDK) return;
+	if(NoGSDK) return;
 	GSDKInternal->SetConnectedPlayers(CurrentlyConnectedPlayers);
 #endif
 }
@@ -129,7 +129,7 @@ void FPlayFabGSDKModule::UpdateConnectedPlayers(const TArray<FConnectedPlayer>& 
 const FString FPlayFabGSDKModule::GetLogsDirectory()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(bNoGSDK) return TEXT("");
+	if(NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(LOG_FOLDER_KEY);
 #endif
 	return TEXT("");
@@ -138,7 +138,7 @@ const FString FPlayFabGSDKModule::GetLogsDirectory()
 const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(bNoGSDK) return TEXT("");
+	if(NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(SHARED_CONTENT_FOLDER_KEY);
 #endif
 
@@ -148,7 +148,7 @@ const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 const TArray<FString> FPlayFabGSDKModule::GetInitialPlayers()
 {
 #if PLAYFAB_GSDK_SERVER
-	if(bNoGSDK) return TArray<FString>();
+	if(NoGSDK) return TArray<FString>();
 	return GSDKInternal->GetInitialPlayers();
 #else
 	return TArray<FString>();

--- a/UnrealPlugin/Source/PlayfabGSDK/Private/PlayfabGSDK.cpp
+++ b/UnrealPlugin/Source/PlayfabGSDK/Private/PlayfabGSDK.cpp
@@ -35,6 +35,13 @@ DEFINE_LOG_CATEGORY(LogPlayFabGSDK);
 void FPlayFabGSDKModule::StartupModule()
 {
 #if PLAYFAB_GSDK_SERVER
+	if(FParse::Param(FCommandLine::Get(), TEXT("noGSDK")) || FParse::Param(FCommandLine::Get(), TEXT("nogsdk")))
+	{
+		UE_LOG(LogPlayFabGSDK, Display, TEXT("Found noGSDK flag in launch args, no GSDK calls will be made."));
+		bNoGSDK = true;
+		return;
+	}
+	
 	GSDKInternal = MakeUnique<FGSDKInternal>();
 
 	GSDKInternal->OnShutdown.BindLambda([this]()
@@ -86,6 +93,7 @@ void FPlayFabGSDKModule::ShutdownModule()
 void FPlayFabGSDKModule::ReadyForPlayers()
 {
 #if PLAYFAB_GSDK_SERVER
+	if(bNoGSDK) return;
 	GSDKInternal->ReadyForPlayers();
 #endif
 }
@@ -93,6 +101,7 @@ void FPlayFabGSDKModule::ReadyForPlayers()
 const FGameServerConnectionInfo FPlayFabGSDKModule::GetGameServerConnectionInfo()
 {
 #if PLAYFAB_GSDK_SERVER
+	if(bNoGSDK) return FGameServerConnectionInfo();
 	return GSDKInternal->GetConnectionInfo();
 #else
 	return FGameServerConnectionInfo();
@@ -102,6 +111,7 @@ const FGameServerConnectionInfo FPlayFabGSDKModule::GetGameServerConnectionInfo(
 FString FPlayFabGSDKModule::GetConfigValue(const FString& Key)
 {
 #if PLAYFAB_GSDK_SERVER
+	if(bNoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(Key);
 #else
 	return TEXT("");
@@ -111,6 +121,7 @@ FString FPlayFabGSDKModule::GetConfigValue(const FString& Key)
 void FPlayFabGSDKModule::UpdateConnectedPlayers(const TArray<FConnectedPlayer>& CurrentlyConnectedPlayers)
 {
 #if PLAYFAB_GSDK_SERVER
+	if(bNoGSDK) return;
 	GSDKInternal->SetConnectedPlayers(CurrentlyConnectedPlayers);
 #endif
 }
@@ -118,6 +129,7 @@ void FPlayFabGSDKModule::UpdateConnectedPlayers(const TArray<FConnectedPlayer>& 
 const FString FPlayFabGSDKModule::GetLogsDirectory()
 {
 #if PLAYFAB_GSDK_SERVER
+	if(bNoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(LOG_FOLDER_KEY);
 #endif
 	return TEXT("");
@@ -126,6 +138,7 @@ const FString FPlayFabGSDKModule::GetLogsDirectory()
 const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 {
 #if PLAYFAB_GSDK_SERVER
+	if(bNoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(SHARED_CONTENT_FOLDER_KEY);
 #endif
 
@@ -135,6 +148,7 @@ const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 const TArray<FString> FPlayFabGSDKModule::GetInitialPlayers()
 {
 #if PLAYFAB_GSDK_SERVER
+	if(bNoGSDK) return TArray<FString>();
 	return GSDKInternal->GetInitialPlayers();
 #else
 	return TArray<FString>();

--- a/UnrealPlugin/Source/PlayfabGSDK/Public/PlayfabGSDK.h
+++ b/UnrealPlugin/Source/PlayfabGSDK/Public/PlayfabGSDK.h
@@ -89,6 +89,9 @@ public:
 	/// <summary>After allocation, returns a list of the initial players that have access to this game server, used by PlayFab's Matchmaking offering</summary>
 	const TArray<FString> GetInitialPlayers();
 
+	/// <summary>Returns whether GSDK calls should be executed (if noGSDK then we are most likely running a local test server, so no MPS agent)</summary>
+	const bool GetIsUsingGsdk() const { return bNoGSDK; }
+
 	static constexpr const TCHAR* HEARTBEAT_ENDPOINT_KEY = TEXT("gsmsBaseUrl");
 	static constexpr const TCHAR* SERVER_ID_KEY = TEXT("instanceId");
 	static constexpr const TCHAR* LOG_FOLDER_KEY = TEXT("logFolder");
@@ -108,4 +111,6 @@ public:
 private:
 
 	TUniquePtr<FGSDKInternal> GSDKInternal = nullptr;
+
+	bool bNoGSDK = false;
 };

--- a/UnrealPlugin/Source/PlayfabGSDK/Public/PlayfabGSDK.h
+++ b/UnrealPlugin/Source/PlayfabGSDK/Public/PlayfabGSDK.h
@@ -89,8 +89,8 @@ public:
 	/// <summary>After allocation, returns a list of the initial players that have access to this game server, used by PlayFab's Matchmaking offering</summary>
 	const TArray<FString> GetInitialPlayers();
 
-	/// <summary>Returns whether GSDK calls should be executed (if noGSDK then we are most likely running a local test server, so no MPS agent)</summary>
-	const bool GetIsUsingGsdk() const { return bNoGSDK; }
+	/// <summary>Returns whether GSDK calls should be executed (if noGSDK flag was found then we are most likely running a local test server, so no MPS agent)</summary>
+	const bool GetIsUsingGsdk() const { return !bNoGSDK; }
 
 	static constexpr const TCHAR* HEARTBEAT_ENDPOINT_KEY = TEXT("gsmsBaseUrl");
 	static constexpr const TCHAR* SERVER_ID_KEY = TEXT("instanceId");

--- a/UnrealPlugin/Source/PlayfabGSDK/Public/PlayfabGSDK.h
+++ b/UnrealPlugin/Source/PlayfabGSDK/Public/PlayfabGSDK.h
@@ -90,7 +90,7 @@ public:
 	const TArray<FString> GetInitialPlayers();
 
 	/// <summary>Returns whether GSDK calls should be executed (if noGSDK flag was found then we are most likely running a local test server, so no MPS agent)</summary>
-	const bool GetIsUsingGsdk() const { return !bNoGSDK; }
+	const bool GetIsUsingGsdk() const { return !NoGSDK; }
 
 	static constexpr const TCHAR* HEARTBEAT_ENDPOINT_KEY = TEXT("gsmsBaseUrl");
 	static constexpr const TCHAR* SERVER_ID_KEY = TEXT("instanceId");
@@ -112,5 +112,5 @@ private:
 
 	TUniquePtr<FGSDKInternal> GSDKInternal = nullptr;
 
-	bool bNoGSDK = false;
+	bool NoGSDK = false;
 };


### PR DESCRIPTION
Closes #127 

**What this PR does / why we need it**:
Adds an optional command line argument for UE servers "-nogsdk" which disables GSDK calls in the UE plugin so that local servers can be easily run for local testing purposes.

Previously if a UE server was run without an MPS agent present then the server would error out. (as expected)

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility