### PR TITLE
add Unity LogMessage

### DIFF
--- a/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
+++ b/UnityGsdk/Assets/PlayFabSdk/MultiplayerAgent/PlayFabMultiplayerAgentAPI.cs
@@ -172,6 +172,13 @@ namespace PlayFab
             return new List<string>(SessionConfig.InitialPlayers);
         }
 
+        // LogMessage uses the Debug.Log method to log a message to the console.
+        // Unity game server process must be started with the "-logfile" parameter to send logs to standard output, where they will be captured when the game server process exits
+        public static void LogMessage(string message)
+        {
+            Debug.Log(message);
+        }
+
         public static IEnumerator SendHeartBeatRequest()
         {
             string payload = _jsonInstance.SerializeObject(CurrentState);


### PR DESCRIPTION
In response to this forum thread [here](https://community.playfab.com/questions/142237/how-to-logmessage-in-linux-container-build.html), we are adding a GSDK LogMessage method that simply uses the Debug.Log method in Unity to send logs to standard output.