### PR TITLE
fix #ifs to remove unreachable code

### DIFF
--- a/UnrealPlugin/Source/PlayFabGSDK/Private/PlayFabGSDK.cpp
+++ b/UnrealPlugin/Source/PlayFabGSDK/Private/PlayFabGSDK.cpp
@@ -132,8 +132,9 @@ const FString FPlayFabGSDKModule::GetLogsDirectory()
 #if PLAYFAB_GSDK_SERVER
 	if (NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(LOG_FOLDER_KEY);
-#endif
+#else
 	return TEXT("");
+#endif
 }
 
 const FString FPlayFabGSDKModule::GetSharedContentDirectory()
@@ -141,9 +142,9 @@ const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 #if PLAYFAB_GSDK_SERVER
 	if (NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(SHARED_CONTENT_FOLDER_KEY);
-#endif
-
+#else
 	return TEXT("");
+#endif
 }
 
 const TArray<FString> FPlayFabGSDKModule::GetInitialPlayers()

--- a/UnrealPlugin/Source/PlayFabGSDK/Public/MaintenanceSchedule.h
+++ b/UnrealPlugin/Source/PlayFabGSDK/Public/MaintenanceSchedule.h
@@ -20,7 +20,7 @@ public:
 	FDateTime NotBefore;
 	FString Description;
 	FString EventSource;
-	int DurationInSeconds;
+	uint32_t DurationInSeconds;
 };
 
 USTRUCT(BlueprintType)

--- a/UnrealPlugin/TestingProject/Plugins/PlayFabGSDK/Source/PlayFabGSDK/Private/PlayFabGSDK.cpp
+++ b/UnrealPlugin/TestingProject/Plugins/PlayFabGSDK/Source/PlayFabGSDK/Private/PlayFabGSDK.cpp
@@ -132,8 +132,9 @@ const FString FPlayFabGSDKModule::GetLogsDirectory()
 #if PLAYFAB_GSDK_SERVER
 	if (NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(LOG_FOLDER_KEY);
-#endif
+#else
 	return TEXT("");
+#endif
 }
 
 const FString FPlayFabGSDKModule::GetSharedContentDirectory()
@@ -141,9 +142,9 @@ const FString FPlayFabGSDKModule::GetSharedContentDirectory()
 #if PLAYFAB_GSDK_SERVER
 	if (NoGSDK) return TEXT("");
 	return GSDKInternal->GetConfigValue(SHARED_CONTENT_FOLDER_KEY);
-#endif
-
+#else
 	return TEXT("");
+#endif
 }
 
 const TArray<FString> FPlayFabGSDKModule::GetInitialPlayers()


### PR DESCRIPTION
UE 5.4 seems to treat "unreachable code" warnings as errors now. These #ifs are now aligned with the other config value getters that already have proper #if usage.