### PR TITLE
force flush print buffer

### DIFF
--- a/cpp/testapps/cppWindowsRunnerGame/main.cpp
+++ b/cpp/testapps/cppWindowsRunnerGame/main.cpp
@@ -41,6 +41,7 @@ static int server_fd;
 void inShutdown()
 {
     printf("GSDK is shutting me down!!!\n");
+    fflush(stdout);
     isShutdown = true;
 
     if (!delayShutdown)
@@ -63,6 +64,7 @@ void maintenanceScheduled(tm t)
 void maintenanceV2Scheduled(Microsoft::Azure::Gaming::MaintenanceSchedule schedule)
 {
     printf("GSDK maintenanceV2 scheduled with %s, %s, %s\n", schedule.m_events[0].m_eventType.c_str(), schedule.m_events[0].m_eventStatus.c_str(), schedule.m_events[0].m_eventSource.c_str());
+    fflush(stdout);
 }
 
 std::string escape(std::string const &s)
@@ -109,11 +111,13 @@ void processRequests()
         if ((new_socket = accept(server_fd, (sockaddr*)&address, &addrlen)) < 0)
         {
             perror("accept");
+            fflush(stdout);
             exit(EXIT_FAILURE);
         }
 
         valread = recv(new_socket, buffer, sizeof(buffer), 0);
         printf("HTTP:Received %.*s\n", valread, buffer);
+        fflush(stdout);
 
         // For each request, "add" a connected player
         players.push_back(Microsoft::Azure::Gaming::ConnectedPlayer("gamer" + std::to_string(requestCount)));
@@ -262,6 +266,7 @@ bool DoesCertificateExist(std::string expectedThumbprint)
                 &cbData))
             {
                 printf("Call #1 to GetCertContextProperty failed.");
+                fflush(stdout);
                 continue;
             }
 
@@ -347,6 +352,7 @@ int main(int argc, char* argv[])
         if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0)
         {
             perror("socket failed");
+            fflush(stdout);
             exit(EXIT_FAILURE);
         }
 
@@ -354,6 +360,7 @@ int main(int argc, char* argv[])
         if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)))
         {
             perror("setsockopt");
+            fflush(stdout);
             exit(EXIT_FAILURE);
         }
         address.sin_family = AF_INET;
@@ -363,12 +370,14 @@ int main(int argc, char* argv[])
         if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0)
         {
             perror("bind failed");
+            fflush(stdout);
             exit(EXIT_FAILURE);
         }
 
         if (listen(server_fd, SOMAXCONN) < 0)
         {
             perror("listen");
+            fflush(stdout);
             exit(EXIT_FAILURE);
         }
 
@@ -384,6 +393,7 @@ int main(int argc, char* argv[])
     catch (const std::exception &ex)
     {
         printf("Exception encountered: %s", ex.what());
+        fflush(stdout);
         Microsoft::Azure::Gaming::GSDK::logMessage(ex.what());
     }
 


### PR DESCRIPTION
C++ test app previously wouldn't have it's printf messages captured properly in the local agent. The print buffer seemingly never got flushed to stdout.