### PR TITLE
Add a way to reset GSDK in cppsdk 

### DIFF
--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -141,7 +141,10 @@ namespace Microsoft
             GSDKInternal::~GSDKInternal()
             {
                 m_keepHeartbeatRunning = false;
-                m_heartbeatThread.join();
+                if (m_heartbeatThread.joinable())
+                {
+                    m_heartbeatThread.join();
+                }
             }
 
 			//Do not need to acquire lock for configuration becase startLog is only called from the constructor.
@@ -508,6 +511,18 @@ namespace Microsoft
             {
                 GSDKInternal::m_debug = debugLogs;
                 GSDKInternal::get();
+            }
+
+            void GSDK::reset()
+            {
+                GSDKInternal::get().m_keepHeartbeatRunning = false;
+
+                if (GSDKInternal::get().m_heartbeatThread.joinable())
+                {
+                    GSDKInternal::get().m_heartbeatThread.join();
+                }
+
+                GSDKInternal::m_instance.reset();
             }
 
             bool GSDK::readyForPlayers()

--- a/cpp/cppsdk/gsdk.h
+++ b/cpp/cppsdk/gsdk.h
@@ -131,6 +131,9 @@ namespace Microsoft
                 /// <param name="debugLogs">Enables outputting additional logs to the GSDK log file.</param>
                 static void start(bool debugLogs = false);
 
+                /// <summary>Resets the GSDK state, joining all threads, requires start to be called before use again</summary>
+                static void reset();
+
                 /// <summary>Tells the Xcloud service information on who is connected.</summary>
                 /// <param name="currentlyConnectedPlayers"></param>
                 static void updateConnectedPlayers(const std::vector<ConnectedPlayer> &currentlyConnectedPlayers);


### PR DESCRIPTION
This PR modifies the cppsdk to add a way to stop GSDK before calling exit() or exiting main. 

Allows user to control lifetime of GSDK, needed to prevent allocations from happening after custom memory allocator has been destroyed. This is done by GSDK::logMessage from the heartbeat thread.
