### PR TITLE
fix unwanted copies of return values

### DIFF
--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -526,7 +526,7 @@ namespace Microsoft
                 return GSDKInternal::get().m_connectionInfo;
             }
 
-            const std::unordered_map<std::string, std::string> &GSDK::getConfigSettings()
+            std::unordered_map<std::string, std::string> GSDK::getConfigSettings()
             {
 				std::lock_guard<std::mutex> lock(GSDKInternal::get().m_configMutex);
                 return GSDKInternal::get().m_configSettings;
@@ -565,19 +565,16 @@ namespace Microsoft
                 return 0;
             }
 
-            const std::string &GSDK::getLogsDirectory()
+            std::string GSDK::getLogsDirectory()
             {
-                // Declare as static so that it doesn't live on the stack (since we're returning a reference)
-                static const std::string empty = "";
-
 				std::lock_guard<std::mutex> lock(GSDKInternal::get().m_configMutex);
 
-                const std::unordered_map<std::string, std::string> config = GSDKInternal::get().m_configSettings;
+                const std::unordered_map<std::string, std::string>& config = GSDKInternal::get().m_configSettings;
                 auto it = config.find(GSDK::LOG_FOLDER_KEY);
 
                 if (it == config.end())
                 {
-                    return empty;
+                    return "";
                 }
                 else
                 {
@@ -585,20 +582,17 @@ namespace Microsoft
                 }
             }
 
-            const std::string &GSDK::getSharedContentDirectory()
+            std::string GSDK::getSharedContentDirectory()
             {
-                // Declare as static so that it doesn't live on the stack (since we're returning a reference)
-                static const std::string empty = "";
-
 				std::lock_guard<std::mutex> lock(GSDKInternal::get().m_configMutex);
 
-				const std::unordered_map<std::string, std::string> config = GSDKInternal::get().m_configSettings;
+				const std::unordered_map<std::string, std::string>& config = GSDKInternal::get().m_configSettings;
 
                 auto it = config.find(GSDK::SHARED_CONTENT_FOLDER_KEY);
 
                 if (it == config.end())
                 {
-                    return empty;
+                    return "";
                 }
                 else
                 {

--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -526,7 +526,7 @@ namespace Microsoft
                 return GSDKInternal::get().m_connectionInfo;
             }
 
-            const std::unordered_map<std::string, std::string> GSDK::getConfigSettings()
+            const std::unordered_map<std::string, std::string> &GSDK::getConfigSettings()
             {
 				std::lock_guard<std::mutex> lock(GSDKInternal::get().m_configMutex);
                 return GSDKInternal::get().m_configSettings;
@@ -565,7 +565,7 @@ namespace Microsoft
                 return 0;
             }
 
-            const std::string& GSDK::getLogsDirectory()
+            const std::string &GSDK::getLogsDirectory()
             {
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";
@@ -585,7 +585,7 @@ namespace Microsoft
                 }
             }
 
-            const std::string& GSDK::getSharedContentDirectory()
+            const std::string &GSDK::getSharedContentDirectory()
             {
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";

--- a/cpp/cppsdk/gsdk.cpp
+++ b/cpp/cppsdk/gsdk.cpp
@@ -565,7 +565,7 @@ namespace Microsoft
                 return 0;
             }
 
-            const std::string GSDK::getLogsDirectory()
+            const std::string& GSDK::getLogsDirectory()
             {
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";
@@ -585,7 +585,7 @@ namespace Microsoft
                 }
             }
 
-            const std::string GSDK::getSharedContentDirectory()
+            const std::string& GSDK::getSharedContentDirectory()
             {
                 // Declare as static so that it doesn't live on the stack (since we're returning a reference)
                 static const std::string empty = "";

--- a/cpp/cppsdk/gsdk.h
+++ b/cpp/cppsdk/gsdk.h
@@ -157,10 +157,10 @@ namespace Microsoft
                 static unsigned int logMessage(const std::string &message);
 
                 /// <summary>Returns a path to the directory where logs will be mapped to the VM host</summary>
-                static const std::string getLogsDirectory();
+                static const std::string& getLogsDirectory();
 
                 /// <summary>Returns a path to the directory shared by all game servers to cache data.</summary>
-                static const std::string getSharedContentDirectory();
+                static const std::string& getSharedContentDirectory();
 
                 /// <summary>After allocation, returns a list of the initial players that have access to this game server, used by PlayFab's Matchmaking offering</summary>
                 static const std::vector<std::string> &getInitialPlayers();

--- a/cpp/cppsdk/gsdk.h
+++ b/cpp/cppsdk/gsdk.h
@@ -125,7 +125,7 @@ namespace Microsoft
 
                 /// <summary>Returns all configuration settings</summary>
                 /// <returns>unordered map of string key:value configuration setting values</returns>
-                static const std::unordered_map<std::string, std::string> getConfigSettings();
+                static const std::unordered_map<std::string, std::string> &getConfigSettings();
 
                 /// <summary>Kicks off communication threads, heartbeats, etc.  Called implicitly by ReadyForPlayers if not called beforehand.</summary>
                 /// <param name="debugLogs">Enables outputting additional logs to the GSDK log file.</param>
@@ -157,10 +157,10 @@ namespace Microsoft
                 static unsigned int logMessage(const std::string &message);
 
                 /// <summary>Returns a path to the directory where logs will be mapped to the VM host</summary>
-                static const std::string& getLogsDirectory();
+                static const std::string &getLogsDirectory();
 
                 /// <summary>Returns a path to the directory shared by all game servers to cache data.</summary>
-                static const std::string& getSharedContentDirectory();
+                static const std::string &getSharedContentDirectory();
 
                 /// <summary>After allocation, returns a list of the initial players that have access to this game server, used by PlayFab's Matchmaking offering</summary>
                 static const std::vector<std::string> &getInitialPlayers();

--- a/cpp/cppsdk/gsdk.h
+++ b/cpp/cppsdk/gsdk.h
@@ -125,7 +125,7 @@ namespace Microsoft
 
                 /// <summary>Returns all configuration settings</summary>
                 /// <returns>unordered map of string key:value configuration setting values</returns>
-                static const std::unordered_map<std::string, std::string> &getConfigSettings();
+                static std::unordered_map<std::string, std::string> getConfigSettings();
 
                 /// <summary>Kicks off communication threads, heartbeats, etc.  Called implicitly by ReadyForPlayers if not called beforehand.</summary>
                 /// <param name="debugLogs">Enables outputting additional logs to the GSDK log file.</param>
@@ -157,10 +157,10 @@ namespace Microsoft
                 static unsigned int logMessage(const std::string &message);
 
                 /// <summary>Returns a path to the directory where logs will be mapped to the VM host</summary>
-                static const std::string &getLogsDirectory();
+                static std::string getLogsDirectory();
 
                 /// <summary>Returns a path to the directory shared by all game servers to cache data.</summary>
-                static const std::string &getSharedContentDirectory();
+                static std::string getSharedContentDirectory();
 
                 /// <summary>After allocation, returns a list of the initial players that have access to this game server, used by PlayFab's Matchmaking offering</summary>
                 static const std::vector<std::string> &getInitialPlayers();


### PR DESCRIPTION
Update public API return types to avoid returning by const value. This improves usability since callers can modify or move the returned value.

In addition this avoids an unnecessary copy of the m_configSettings hashmap while under the config mutex