### PR TITLE
Fix GSDK Unreal Plugin compatibility with UE 5.6 and UE 5.7

### DIFF
--- a/UnrealPlugin/TestingProject/Source/SlateUGS/Private/TestGameInstanceGSDK.cpp
+++ b/UnrealPlugin/TestingProject/Source/SlateUGS/Private/TestGameInstanceGSDK.cpp
@@ -1,22 +1,22 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 
-#include "TestGameInstance.h"
+#include "TestGameInstanceGSDK.h"
 
 DEFINE_LOG_CATEGORY(LogPlayFabGSDKGameInstance);
 
-void UTestGameInstance::Init()
+void UTestGameInstanceGSDK::Init()
 {
 	FOnGSDKShutdown_Dyn OnGsdkShutdown;
-	OnGsdkShutdown.BindDynamic(this, &UTestGameInstance::OnGSDKShutdown);
+	OnGsdkShutdown.BindDynamic(this, &UTestGameInstanceGSDK::OnGSDKShutdown);
 	FOnGSDKHealthCheck_Dyn OnGsdkHealthCheck;
-	OnGsdkHealthCheck.BindDynamic(this, &UTestGameInstance::OnGSDKHealthCheck);
+	OnGsdkHealthCheck.BindDynamic(this, &UTestGameInstanceGSDK::OnGSDKHealthCheck);
 	FOnGSDKServerActive_Dyn OnGSDKServerActive;
-	OnGSDKServerActive.BindDynamic(this, &UTestGameInstance::OnGSDKServerActive);
+	OnGSDKServerActive.BindDynamic(this, &UTestGameInstanceGSDK::OnGSDKServerActive);
 	FOnGSDKReadyForPlayers_Dyn OnGSDKReadyForPlayers;
-	OnGSDKReadyForPlayers.BindDynamic(this, &UTestGameInstance::OnGSDKReadyForPlayers);
+	OnGSDKReadyForPlayers.BindDynamic(this, &UTestGameInstanceGSDK::OnGSDKReadyForPlayers);
 	FOnGSDKMaintenanceV2_Dyn OnGSDKMaintenanceV2;
-	OnGSDKMaintenanceV2.BindDynamic(this, &UTestGameInstance::OnGSDKMaintenanceV2);
+	OnGSDKMaintenanceV2.BindDynamic(this, &UTestGameInstanceGSDK::OnGSDKMaintenanceV2);
 
 	UGSDKUtils::RegisterGSDKShutdownDelegate(OnGsdkShutdown);
 	UGSDKUtils::RegisterGSDKHealthCheckDelegate(OnGsdkHealthCheck);
@@ -30,25 +30,25 @@ void UTestGameInstance::Init()
 #endif
 }
 
-void UTestGameInstance::OnStart()
+void UTestGameInstanceGSDK::OnStart()
 {
 	UE_LOG(LogPlayFabGSDKGameInstance, Warning, TEXT("Reached onStart!"));
 	UGSDKUtils::ReadyForPlayers();
 }
 
-void UTestGameInstance::OnGSDKShutdown()
+void UTestGameInstanceGSDK::OnGSDKShutdown()
 {
 	UE_LOG(LogPlayFabGSDKGameInstance, Warning, TEXT("Shutdown!"));
 	FPlatformMisc::RequestExit(false);
 }
 
-bool UTestGameInstance::OnGSDKHealthCheck()
+bool UTestGameInstanceGSDK::OnGSDKHealthCheck()
 {
 	UE_LOG(LogPlayFabGSDKGameInstance, Warning, TEXT("Healthy!"));
 	return true;
 }
 
-void UTestGameInstance::OnGSDKServerActive()
+void UTestGameInstanceGSDK::OnGSDKServerActive()
 {
 	/**
 	 * Server is transitioning to an active state.
@@ -58,7 +58,7 @@ void UTestGameInstance::OnGSDKServerActive()
 	UE_LOG(LogPlayFabGSDKGameInstance, Warning, TEXT("Active!"));
 }
 
-void UTestGameInstance::OnGSDKReadyForPlayers()
+void UTestGameInstanceGSDK::OnGSDKReadyForPlayers()
 {
 	/**
 	 * Server is transitioning to a StandBy state. Game initialization is complete and the game is ready
@@ -69,7 +69,7 @@ void UTestGameInstance::OnGSDKReadyForPlayers()
 	UE_LOG(LogPlayFabGSDKGameInstance, Warning, TEXT("Finished Initialization - Moving to StandBy!"));
 }
 
-void UTestGameInstance::OnGSDKMaintenanceV2(const FMaintenanceSchedule& schedule)
+void UTestGameInstanceGSDK::OnGSDKMaintenanceV2(const FMaintenanceSchedule& schedule)
 {
 	/**
 	* Server recieved a maintenance event.

--- a/UnrealPlugin/TestingProject/Source/SlateUGS/Public/TestGameInstanceGSDK.h
+++ b/UnrealPlugin/TestingProject/Source/SlateUGS/Public/TestGameInstanceGSDK.h
@@ -5,7 +5,7 @@
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
 #include "GSDKUtils.h"
-#include "TestGameInstance.generated.h"
+#include "TestGameInstanceGSDk.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogPlayFabGSDKGameInstance, Log, All);
 
@@ -13,7 +13,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogPlayFabGSDKGameInstance, Log, All);
  * 
  */
 UCLASS()
-class SLATEUGS_API UTestGameInstance : public UGameInstance
+class SLATEUGS_API UTestGameInstanceGSDK : public UGameInstance
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
## Summary
Resolved breaking changes introduced in UE 5.6 and UE 5.7 that prevented 
the GSDK Unreal plugin from building and cooking successfully.

## Root Causes
- UE 5.6 introduced `CQTest` module with conflicting header name